### PR TITLE
[#1] Add GitHub Actions CI/CD

### DIFF
--- a/.github/scripts/ci/format.sh
+++ b/.github/scripts/ci/format.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Format the wiki. CI passes --check; Release passes --write.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$root"
+
+mode="${1:---check}"
+
+# Markdown is not auto-reflowed: tables and Mermaid break. YAML / JSON / HTML are.
+npx --yes prettier@3.6.2 "$mode" \
+  --ignore-path .prettierignore \
+  --print-width 100 \
+  ".github/**/*.{yml,yaml}" \
+  "_config.yml" \
+  "_includes/**/*.html" \
+  ".prettierrc.json"

--- a/.github/scripts/ci/next_version.py
+++ b/.github/scripts/ci/next_version.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Compute the next SemVer for the Release workflow.
+
+Environment:
+  INPUT_VERSION  optional exact X.Y.Z (or vX.Y.Z)
+  INPUT_BUMP     auto | patch | minor | major  (used when INPUT_VERSION is empty)
+
+Prints X.Y.Z to stdout. Exits non-zero on invalid input or a non-increasing version.
+
+1.0.0 is never chosen automatically — pass INPUT_VERSION=1.0.0 for the academic ship.
+While major is 0, a breaking-change auto bump increments minor (SemVer §4).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+BREAKING = re.compile(r"^\w+(\([^)]*\))?!:")
+
+
+def run(args: list[str]) -> str:
+    return subprocess.check_output(args, text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def parsed_tags() -> list[tuple[int, int, int]]:
+    try:
+        raw = run(["git", "tag", "-l", "v*"])
+    except subprocess.CalledProcessError:
+        return []
+    found: list[tuple[int, int, int]] = []
+    for line in raw.splitlines():
+        match = SEMVER.match(line.strip())
+        if match:
+            found.append(tuple(int(g) for g in match.groups()))  # type: ignore[arg-type]
+    found.sort()
+    return found
+
+
+def fmt(ver: tuple[int, int, int]) -> str:
+    return f"{ver[0]}.{ver[1]}.{ver[2]}"
+
+
+def apply_bump(current: tuple[int, int, int], bump: str) -> tuple[int, int, int]:
+    major, minor, patch = current
+    if bump == "major":
+        if major == 0:
+            return (0, minor + 1, 0)
+        return (major + 1, 0, 0)
+    if bump == "minor":
+        return (major, minor + 1, 0)
+    if bump == "patch":
+        return (major, minor, patch + 1)
+    sys.exit(f"Unknown bump: {bump}")
+
+
+def subjects_since(tag: str | None) -> list[str]:
+    rev = f"{tag}..HEAD" if tag else "HEAD"
+    try:
+        return run(["git", "log", rev, "--pretty=%s"]).splitlines()
+    except subprocess.CalledProcessError:
+        return []
+
+
+def auto_bump(current: tuple[int, int, int], subjects: list[str]) -> tuple[int, int, int]:
+    kind = "patch"
+    for subject in subjects:
+        lower = subject.lower()
+        if BREAKING.match(subject) or "breaking change" in lower:
+            kind = "major"
+            break
+        if lower.startswith("feat:") or lower.startswith("feat("):
+            kind = "minor"
+    return apply_bump(current, kind)
+
+
+def main() -> None:
+    manual = os.environ.get("INPUT_VERSION", "").strip()
+    bump = (os.environ.get("INPUT_BUMP") or "auto").strip().lower() or "auto"
+    tags = parsed_tags()
+    current = tags[-1] if tags else (0, 1, 0)
+
+    if manual:
+        match = SEMVER.match(manual)
+        if not match:
+            sys.exit(f"Invalid SemVer: {manual!r} (expected X.Y.Z)")
+        nxt = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    elif bump == "auto":
+        last_tag = f"v{fmt(current)}" if tags else None
+        nxt = auto_bump(current, subjects_since(last_tag))
+    elif bump in {"patch", "minor", "major"}:
+        nxt = apply_bump(current, bump)
+    else:
+        sys.exit(f"Unknown bump: {bump}")
+
+    if tags and nxt <= current:
+        sys.exit(f"Next version {fmt(nxt)} is not greater than current {fmt(current)}")
+
+    if nxt[0] >= 1 and not manual:
+        sys.exit(
+            "Refusing to publish 1.0.0 (or higher) automatically. "
+            "Re-run with version=1.0.0 when that is the academic ship."
+        )
+
+    print(fmt(nxt))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/ci/prepare_changelog.py
+++ b/.github/scripts/ci/prepare_changelog.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Move CHANGELOG.md Unreleased notes into a dated ## [X.Y.Z] section."""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG = Path("CHANGELOG.md")
+# Keep a Changelog files in this repo live under 90-Changelog/
+CANDIDATES = [
+    Path("90-Changelog/CHANGELOG.md"),
+    Path("CHANGELOG.md"),
+]
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: prepare_changelog.py X.Y.Z")
+    version = sys.argv[1]
+    if not re.match(r"^\d+\.\d+\.\d+$", version):
+        sys.exit(f"invalid version: {version}")
+
+    path = next((p for p in CANDIDATES if p.is_file()), None)
+    if path is None:
+        sys.exit("CHANGELOG.md not found")
+
+    text = path.read_text(encoding="utf-8")
+    match = re.search(
+        r"^## \[Unreleased\]\s*\n(.*?)(?=^## \[)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        sys.exit("Could not find ## [Unreleased] section")
+
+    body = match.group(1).rstrip() + "\n"
+    if not body.strip():
+        body = "### Changed\n\n- Release workflow published this version.\n"
+
+    today = dt.date.today().isoformat()
+    replacement = (
+        f"## [Unreleased]\n\n"
+        f"### Added\n\n"
+        f"### Changed\n\n"
+        f"## [{version}] — {today}\n\n"
+        f"{body.lstrip()}\n"
+    )
+    new_text = text[: match.start()] + replacement + text[match.end() :]
+
+    # Keep-a-changelog footer links, if present
+    unreleased_link = re.search(r"^\[Unreleased\]:\s+\S+\s*$", new_text, flags=re.MULTILINE)
+    if unreleased_link:
+        new_text = (
+            new_text[: unreleased_link.end()]
+            + f"\n[{version}]: https://github.com/Projet-de-compensation-2025-2026/"
+            f"{Path('.').resolve().name}/releases/tag/v{version}"
+            + new_text[unreleased_link.end() :]
+        )
+
+    path.write_text(new_text, encoding="utf-8")
+    print(f"Updated {path} for {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/ci/smoke.sh
+++ b/.github/scripts/ci/smoke.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Prove the *built* wiki runs: serve _site and curl a real HTML page.
+# A successful Jekyll compile is not enough; this process must answer HTTP.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$root"
+
+if [[ ! -d _site ]]; then
+  echo "SMOKE FAIL: _site/ is missing. Build Jekyll before this script." >&2
+  exit 1
+fi
+
+port="${SMOKE_PORT:-4173}"
+python3 -m http.server "$port" --bind 127.0.0.1 --directory _site &
+server_pid=$!
+cleanup() { kill "$server_pid" 2>/dev/null || true; }
+trap cleanup EXIT
+
+ok=0
+for _ in $(seq 1 40); do
+  for path in "/" "/index.html" "/gym-buddy-documentation/" "/gym-buddy-documentation/index.html"; do
+    body="$(curl -fsS "http://127.0.0.1:${port}${path}" 2>/dev/null || true)"
+    if [[ "$body" == *"Gym Buddies"* ]]; then
+      echo "SMOKE OK: ${path} returned HTML containing 'Gym Buddies'"
+      ok=1
+      break 2
+    fi
+  done
+  sleep 0.25
+done
+
+if [[ "$ok" -ne 1 ]]; then
+  echo "SMOKE FAIL: static server never returned a Gym Buddies page on port ${port}" >&2
+  echo "--- _site listing (first 40) ---" >&2
+  find _site -maxdepth 3 -type f | head -40 >&2 || true
+  exit 1
+fi

--- a/.github/scripts/ci/test.sh
+++ b/.github/scripts/ci/test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Structural tests for the documentation wiki.
+# Application repos replace this file with JUnit / ng test / spec lint.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$root"
+
+python3 - <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(".").resolve()
+skip_dir_names = {
+    ".git",
+    ".github",
+    "_includes",
+    "_site",
+    ".jekyll-cache",
+    "node_modules",
+    "vendor",
+}
+
+missing_readme = []
+for path in sorted(root.rglob("*")):
+    if not path.is_dir():
+        continue
+    if any(part in skip_dir_names for part in path.relative_to(root).parts):
+        continue
+    if not (path / "README.md").is_file():
+        missing_readme.append(str(path.relative_to(root)))
+
+required = [
+    Path("70-Engineering-practices/07-CI-CD.md"),
+    Path(".github/workflows/ci.yml"),
+    Path(".github/workflows/release.yml"),
+    Path(".github/workflows/deploy.yml"),
+    Path(".github/scripts/ci/format.sh"),
+    Path(".github/scripts/ci/smoke.sh"),
+    Path(".github/scripts/ci/next_version.py"),
+    Path(".github/scripts/ci/prepare_changelog.py"),
+    Path("_config.yml"),
+    Path("README.md"),
+]
+missing_required = [str(p) for p in required if not p.is_file()]
+
+errors = []
+if missing_readme:
+    errors.append("Folders without README.md:\n  - " + "\n  - ".join(missing_readme))
+if missing_required:
+    errors.append("Missing required pipeline files:\n  - " + "\n  - ".join(missing_required))
+
+if errors:
+    print("TEST FAIL\n" + "\n".join(errors), file=sys.stderr)
+    sys.exit(1)
+
+print("TEST OK: every content folder has README.md and pipeline files exist")
+PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop]
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: false
+
+      - name: Format
+        run: bash .github/scripts/ci/format.sh --check
+
+      - name: Test
+        run: bash .github/scripts/ci/test.sh
+
+      - name: Build site
+        run: |
+          bundle install
+          bundle exec jekyll build --baseurl /gym-buddy-documentation
+
+      - name: Smoke (site must respond)
+        run: bash .github/scripts/ci/smoke.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+
+# A successful tagged squash commit on main is the deploy.
+# GITHUB_TOKEN tag pushes do not re-enter this file; Release calls it via workflow_call.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  pages:
+    name: pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: false
+
+      - name: Build site
+        run: |
+          bundle install
+          bundle exec jekyll build --baseurl /gym-buddy-documentation
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SemVer to publish (e.g. 0.2.0). Leave empty to compute automatically."
+        required: false
+        type: string
+      bump:
+        description: "When version is empty: auto (from Conventional Commits), patch, minor, or major."
+        required: false
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
+
+# Dedicated release pipeline: format → test → smoke → squash onto main → tag.
+# This is the only writer of main.
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: false
+
+      - name: Format (apply)
+        run: bash .github/scripts/ci/format.sh --write
+
+      - name: Test
+        run: bash .github/scripts/ci/test.sh
+
+      - name: Build site
+        run: |
+          bundle install
+          bundle exec jekyll build --baseurl /gym-buddy-documentation
+
+      - name: Smoke (site must respond)
+        run: bash .github/scripts/ci/smoke.sh
+
+      - name: Compute version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUMP: ${{ inputs.bump }}
+        run: |
+          VER="$(python3 .github/scripts/ci/next_version.py)"
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "Releasing v${VER}"
+
+      - name: Prepare changelog
+        run: python3 .github/scripts/ci/prepare_changelog.py "${{ steps.version.outputs.version }}"
+
+      - name: Commit release prep on develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No prep changes"
+          else
+            git commit -m "chore(release): prepare v${{ steps.version.outputs.version }}"
+            git push origin HEAD:develop
+          fi
+
+      - name: Squash develop onto main and tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch origin
+          git checkout -B main origin/main
+          git merge --squash origin/develop
+          git commit -m "release: v${VERSION}"
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+          git push origin main
+          git push origin "v${VERSION}"
+          git checkout develop
+          git merge --no-ff main -m "chore(release): sync develop with v${VERSION}"
+          git push origin develop
+
+  deploy:
+    name: deploy
+    needs: release
+    uses: ./.github/workflows/deploy.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ desktop.ini
 _site/
 .jekyll-cache/
 .jekyll-metadata
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+_site
+.jekyll-cache
+.jekyll-metadata
+node_modules
+vendor
+*.pdf
+*.md
+LICENSE
+Gemfile
+Gemfile.lock
+.git

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "proseWrap": "preserve",
+  "printWidth": 100,
+  "overrides": [
+    {
+      "files": ["*.md"],
+      "options": {
+        "proseWrap": "preserve"
+      }
+    }
+  ]
+}

--- a/10-Getting-started/03-Glossary.md
+++ b/10-Getting-started/03-Glossary.md
@@ -25,6 +25,10 @@
 | Back-office | Staff UI for admins and moderators |
 | Controlled file | Any stored blob (image, audio) reachable only after authorization |
 | JWT | JSON Web Token used as the access credential |
+| CI | Continuous integration: format, tests, and a live smoke on every `develop` PR |
+| Release | Dedicated workflow that squash-merges `develop` onto `main` and tags SemVer |
+| Deploy | What happens after that tag: Pages and/or Docker on the VM |
+| GHCR | GitHub Container Registry (`ghcr.io`) for versioned service images |
 | Organizer | Member who created an event (role on that event, not a global role) |
 
 Identifiers in specs look like `FS-EVENTS-03` (functional) or `TS-JWT-02` (technical). Use them in tests and review comments.

--- a/20-Architecture/08-Hosting-and-GitHub-Pages.md
+++ b/20-Architecture/08-Hosting-and-GitHub-Pages.md
@@ -71,7 +71,9 @@ Host them next to GitHub, not on Pages. Reasonable student options:
 | PostgreSQL 18 | [Neon](https://neon.tech/), [Supabase](https://supabase.com/), Railway, Azure Database for PostgreSQL, or the same host as the API |
 | Object storage | Cloudflare R2, AWS S3, or MinIO on the same VM |
 
-GitHub Actions builds the JAR and deploys to that host; it also builds Angular and OpenAPI docs to Pages. Compose remains the **local** story.
+GitHub Actions is the only pipeline: CI on `develop`, a separate Release job onto `main`, then Deploy. Details: [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md).
+
+A tagged squash commit on `main` **is** the deploy. Static repos (this wiki, Angular, OpenAPI UI) go to GitHub Pages. `gym-buddy-service` builds a Docker image to GHCR and, when `DEPLOY_*` secrets exist, replaces the container on the VM. Compose remains the **local** story.
 
 ## Target topology
 

--- a/20-Architecture/README.md
+++ b/20-Architecture/README.md
@@ -13,7 +13,7 @@ How Gym Buddies is split into systems, where data lives, and why the proposed st
 | [05-Back-office.md](05-Back-office.md) | Admin / moderator console |
 | [06-Data-model.md](06-Data-model.md) | Relational model covering every overview feature |
 | [07-Technology-choices.md](07-Technology-choices.md) | Java 26, Angular 22, TypeScript 7, PostgreSQL 18, OpenAPI repo |
-| [08-Hosting-and-GitHub-Pages.md](08-Hosting-and-GitHub-Pages.md) | What Pages can host (wiki, Angular, OpenAPI UI) and what it cannot (Java, PostgreSQL) |
+| [08-Hosting-and-GitHub-Pages.md](08-Hosting-and-GitHub-Pages.md) | What Pages can host (wiki, Angular, OpenAPI UI) and what it cannot (Java, PostgreSQL). Deploy is the tagged Release — see [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md) |
 
 Implementation details that are not architectural (JWT shape, signed URLs, fixture generation) live in [40-Technical-specifications](../40-Technical-specifications/README.md).
 

--- a/70-Engineering-practices/02-Git-workflow.md
+++ b/70-Engineering-practices/02-Git-workflow.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Approved |
-| Related | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md), [06-Versioning.md](06-Versioning.md) |
+| Related | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md), [06-Versioning.md](06-Versioning.md), [07-CI-CD.md](07-CI-CD.md) |
 
 Gym Buddies follows the **Gitflow** branching model as documented by Atlassian:
 
@@ -18,9 +18,11 @@ Gitflow fits a **release-based** academic project: `1.0.0` is the compensation-p
 1. A `develop` branch is created from `main`
 2. `feature/*` branches are created from `develop`
 3. When a feature is complete it is merged into `develop`
-4. A `release/*` branch is created from `develop` when a version is being prepared
-5. When the release is done it is merged into `develop` **and** `main`, and `main` is tagged
-6. If production is broken, a `hotfix/*` branch is created from `main` and merged back into both `main` and `develop`
+4. A version is cut by the **Release** workflow in [07-CI-CD.md](07-CI-CD.md) (the Jenkins-style job). It format-checks, tests, smokes, then **squash-merges `develop` onto `main`** and tags `vX.Y.Z`.
+5. `main` therefore contains **only** those tagged squash commits. Humans do not push to `main`. Feature PRs never target `main`.
+6. If production is broken, a `hotfix/*` branch is created from `main`, merged into `develop`, then Release is run again so `main` still only moves by a tagged squash.
+
+A long-lived `release/*` freeze branch remains allowed (Atlassian). Day-to-day we do not open one: the Release workflow *is* the release.
 
 `feature` branches **never** merge into `main`.
 
@@ -28,11 +30,11 @@ Gitflow fits a **release-based** academic project: `1.0.0` is the compensation-p
 
 | Branch | Role (Atlassian) | Our convention |
 | --- | --- | --- |
-| `main` | Official release history | Tagged with a [SemVer](https://semver.org/) version (`v0.2.0`, later `v1.0.0`) |
-| `develop` | Integration of finished features | Default integration branch |
+| `main` | Official release history | **Only** tagged squash commits from Release (`v0.2.0`, later `v1.0.0`) |
+| `develop` | Integration of finished features | Default branch. Every PR/push runs CI |
 | `feature/<ticket>-<slug>` | One feature, parent = `develop` | Ticket id when the work has a ticket: `feature/42-event-capacity` |
-| `release/<semver>` | Freeze for a version | `release/0.3.0`, then `release/1.0.0` for the academic ship |
-| `hotfix/<ticket>-<slug>` | Patch production, parent = `main` | `hotfix/88-jwt-refresh` |
+| `release/<semver>` | Optional freeze | Prefer the Release workflow; use a branch only for a long freeze |
+| `hotfix/<ticket>-<slug>` | Patch production, parent = `main` | Land on `develop`, then run Release |
 
 Documentation-only work in this wiki uses the same model (`feature/12-fix-search-spec` off `develop`).
 
@@ -92,7 +94,7 @@ Product and specification work should still start from a ticket. Ticket-less com
 
 ## Pull requests
 
-- Open the PR against `develop` (features) or `main` (hotfixes)
+- Open the PR against `develop`. Never against `main` (Release owns `main`; see [07-CI-CD.md](07-CI-CD.md))
 - Title includes the ticket when there is one: `[#42] Reject accept when the event is full`
 - Description links the ticket and the wiki page the ticket already points at
 - Review checklist: [03-Review-process.md](03-Review-process.md)

--- a/70-Engineering-practices/03-Review-process.md
+++ b/70-Engineering-practices/03-Review-process.md
@@ -19,6 +19,7 @@ Even on an individual project, every merge to `develop` (features) or `main` (re
 - [ ] JWT / ACL: fail closed, no existence leak
 - [ ] Fixtures still run (or not required)
 - [ ] Changelog note if user-visible
+- [ ] CI workflow **`ci`** is green on the PR (format, tests, smoke) — see [07-CI-CD.md](07-CI-CD.md)
 
 ## What “looks good” is not enough
 

--- a/70-Engineering-practices/06-Versioning.md
+++ b/70-Engineering-practices/06-Versioning.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Approved |
-| Related | [02-Git-workflow.md](02-Git-workflow.md), [../90-Changelog/CHANGELOG.md](../90-Changelog/CHANGELOG.md) |
+| Related | [02-Git-workflow.md](02-Git-workflow.md), [07-CI-CD.md](07-CI-CD.md), [../90-Changelog/CHANGELOG.md](../90-Changelog/CHANGELOG.md) |
 
 Gym Buddies versions follow **Semantic Versioning 2.0.0**:
 
@@ -23,7 +23,20 @@ Until `1.0.0` we stay on **major version 0**. We do **not** jump to `1.x` for in
 
 Start at `0.1.0`. During `0.y.z`, increment **y** when we add a feature slice worth tagging, and **z** for fixes, as SemVer’s own FAQ recommends for initial development. Tags on `main` look like `v0.1.0`, `v0.2.0`, `v0.2.1`, … then `v1.0.0`.
 
-Gitflow: only commits on `main` are tagged. `develop` is unreleased (`Unreleased` in the changelog).
+Gitflow: only commits on `main` are tagged, and only by the Release workflow ([07-CI-CD.md](07-CI-CD.md)). `develop` is unreleased (`Unreleased` in the changelog).
+
+## Who picks the number
+
+The Release workflow computes the next version unless you type one.
+
+| How you start Release | Result |
+| --- | --- |
+| `gh workflow run Release` | `auto`: `feat` → minor, breaking → minor while on `0.y.z` (major after `1.0.0`), otherwise patch |
+| `gh workflow run Release -f bump=minor` | Force that bump from the latest `v*` tag |
+| `gh workflow run Release -f version=0.4.0` | Use **exactly** `0.4.0` (must be greater than the latest tag) |
+| `gh workflow run Release -f version=1.0.0` | Academic ship. **`1.0.0` is never chosen automatically** |
+
+The number is written as an annotated git tag `vX.Y.Z` on the squash commit on `main`.
 
 ## What each number means (after 1.0.0)
 
@@ -52,4 +65,4 @@ A backend must not claim `1.0.0` while it implements an OpenAPI document still a
 
 Each repository keeps a `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. This wiki’s file is [../90-Changelog/CHANGELOG.md](../90-Changelog/CHANGELOG.md).
 
-Move bullets from `Unreleased` to a dated `## [0.y.z]` section when the Gitflow `release/*` branch is merged to `main`.
+Move bullets from `Unreleased` to a dated `## [0.y.z]` section when the Release workflow squash-merges to `main`. The workflow does this itself (`prepare_changelog.py`).

--- a/70-Engineering-practices/07-CI-CD.md
+++ b/70-Engineering-practices/07-CI-CD.md
@@ -1,0 +1,186 @@
+# CI/CD
+
+| Field | Value |
+| --- | --- |
+| Status | Approved |
+| Related | [02-Git-workflow.md](02-Git-workflow.md), [06-Versioning.md](06-Versioning.md), [../20-Architecture/08-Hosting-and-GitHub-Pages.md](../20-Architecture/08-Hosting-and-GitHub-Pages.md) |
+
+How Gym Buddies is built, proven, released, and put on a machine. Tooling is **GitHub Actions** (the Jenkins-style job runner that lives next to the code). There is no separate Jenkins server.
+
+## What we are automating
+
+Three promises, three workflows. They are not the same job.
+
+| Workflow | File | Trigger | Promise |
+| --- | --- | --- | --- |
+| **CI** | `.github/workflows/ci.yml` | Every pull request **to `develop`**, and every push **on `develop`** | The change is formatted, tested, and the built artifact actually **runs** |
+| **Release** | `.github/workflows/release.yml` | Manual `workflow_dispatch` (the “Jenkins release” button) | Format → test → smoke → **squash-merge `develop` onto `main`** → **annotated tag `vX.Y.Z`** |
+| **Deploy** | `.github/workflows/deploy.yml` | A `v*` tag on `main`, or called by Release | Distribute that version: GitHub Pages and/or a Docker image on the target VM |
+
+`main` is **only** those tagged squash commits. Humans do not push to `main`. Feature branches never target `main`.
+
+```text
+feature/* ──PR──► develop          CI on every PR and every push
+                      │
+                      │  Actions → Release  (button, optional version)
+                      ▼
+                    main   one squash commit + tag vX.Y.Z
+                      │
+                      ▼
+                   Deploy  Pages and/or docker pull on the VM
+```
+
+## CI vs CD (the words)
+
+| | Continuous integration | Continuous delivery | Continuous deployment |
+| --- | --- | --- | --- |
+| Question | Does this change still build, stay formatted, pass tests, and **run**? | Could we ship this right now? | Did we just ship it? |
+| Here | The **CI** workflow on `develop` | The **Release** workflow: it *could* publish, but a human starts it | The **Deploy** workflow after a successful tagged commit on `main` |
+
+We do **not** deploy every green commit on `develop`. We do deploy every successful **tagged** squash commit on `main`. That is continuous deployment of **releases**, not of every merged feature.
+
+## How this is operated (no extra website required)
+
+Everything is Git + the GitHub API:
+
+- Workflows live in the repository. Pushing them to `develop` is enough for GitHub to register them.
+- You start a release from **Actions → Release → Run workflow**, or `gh workflow run Release`.
+- Branch rules, the `develop` default branch, and GitHub Pages can be set with `gh` (and are, when this page is first applied).
+- The only thing that **cannot** be invented from a laptop is a machine you have not given us: SSH host, user, and key. Those go in repository **Actions secrets**. Until they exist, Deploy still builds and publishes the image (or Pages site) and **skips** the SSH step.
+
+You do not need Jenkins, a second CI product, or to click through GitHub’s UI for the pipelines themselves.
+
+## Success criteria (this page’s contract)
+
+1. **Every pull request targeting `develop` starts the CI workflow.** A push directly to `develop` does too.
+2. **`main` only moves via the Release workflow.** The result is a **squash** commit whose message is `release: vX.Y.Z` and an annotated tag `vX.Y.Z` on that commit.
+3. Release **fails closed**: if format, tests, or the smoke run fail, there is **no** commit on `main` and **no** tag.
+4. Versioning is **automatic** from Conventional Commits and the previous tag. You may **override** the number when you start the workflow.
+5. A successful tag on `main` **is** the deploy: Pages for static repos, Docker image + VM replace for `gym-buddy-service`.
+
+## The three jobs in detail
+
+### CI — prove the change
+
+Runs on `ubuntu-latest`. It never publishes.
+
+| Step | What “pass” means |
+| --- | --- |
+| Format | The tree matches the formatter. This wiki: Prettier on YAML / JSON / HTML (`prettier --check`). Markdown is **not** auto-reflowed (tables and Mermaid). Application repos: Spotless / Prettier. CI does **not** rewrite files. |
+| Test | Repo-specific tests. In this wiki: every content folder still has a `README.md`, required pipeline files exist. Later: JUnit, Angular unit tests, OpenAPI lint. |
+| Smoke | The **built** thing is started and answers HTTP. Compiling is not enough. This wiki: Jekyll writes `_site/`, a local static server is started, `curl` must get a page that contains “Gym Buddies”. Service: container starts and `/` or `/actuator/health` returns 2xx. |
+
+Required check name on `develop`: **`ci`**.
+
+### Release — the dedicated “make a version” pipeline
+
+This is the Jenkins-style job. It is **not** folded into CI.
+
+Start it on `develop`:
+
+```bash
+gh workflow run Release
+# or pin the number
+gh workflow run Release -f version=0.2.0
+# or force the bump kind
+gh workflow run Release -f bump=minor
+```
+
+Inputs:
+
+| Input | Default | Meaning |
+| --- | --- | --- |
+| `version` | empty | If set (e.g. `0.3.0` or `1.0.0`), that number is used. Must be SemVer `X.Y.Z` and **greater** than the latest `v*` tag. |
+| `bump` | `auto` | Used only when `version` is empty: `auto`, `patch`, `minor`, `major`. |
+
+`auto` reads commit subjects on `develop` since the last tag:
+
+| Commits since last tag | Bump |
+| --- | --- |
+| `feat!:` / `type!:` / `BREAKING CHANGE` | major — except while we are on `0.y.z`, a breaking change bumps **minor** (SemVer §4). **`1.0.0` is never chosen automatically**; pass `version=1.0.0` for the academic ship. |
+| `feat:` / `feat(…):` | minor |
+| anything else (`fix`, `docs`, `chore`, `ci`, …) | patch |
+
+If there is no `v*` tag yet, the baseline is the last changelog version (`0.1.0` for this wiki).
+
+Release then, in order:
+
+1. Checks out `develop` (full history + tags).
+2. **Applies** the formatter (`prettier --write`).
+3. Runs the same tests as CI.
+4. Builds the project and **smokes it** (process up, HTTP 2xx).
+5. Computes the version (manual or automatic).
+6. Moves `CHANGELOG.md` bullets from `Unreleased` into `## [X.Y.Z] — <date>`.
+7. Commits any prep onto `develop` as `chore(release): prepare vX.Y.Z`.
+8. `git merge --squash` of `develop` onto `main`, commit `release: vX.Y.Z`, annotated tag `vX.Y.Z`, push `main` and the tag.
+9. Merges `main` back into `develop` (`chore(release): sync develop with vX.Y.Z`) so the next squash does not replay history.
+10. Calls **Deploy**.
+
+If any of 2–4 fail, steps 7–10 do not run.
+
+### Deploy — distribution
+
+Triggered by the `v*` tag (and always invoked by Release, because a push made with `GITHUB_TOKEN` does not start new workflows).
+
+| Repository | Artifact | Where it goes |
+| --- | --- | --- |
+| `gym-buddy-documentation` | Jekyll `_site/` | GitHub Pages |
+| `gym-buddy-ui` | `ng build` static files | GitHub Pages |
+| `gym-buddy-openapi` | Spec + Swagger/Redoc | GitHub Pages |
+| `gym-buddy-service` | Docker image | `ghcr.io/<owner>/gym-buddy-service:vX.Y.Z` **and**, if SSH secrets exist, `docker pull` + replace the container on the VM |
+
+Service deploy on the VM (when secrets are set):
+
+1. Build `docker build` of the tagged commit.
+2. Push to GHCR.
+3. SSH to `DEPLOY_HOST` and run the replace script (pull the new tag, `docker compose up -d`, drop the previous container).
+
+## Repository rules (so `main` stays clean)
+
+| Branch | Rule |
+| --- | --- |
+| `develop` | Default branch. PRs target this. Status check **`ci`** must be green to merge. No force-push, no delete. |
+| `main` | Linear history only. No force-push, no delete. **Not** opened by feature PRs. Only Release writes it. |
+| `feature/*` | From `develop`, PR back to `develop`. |
+| `release/*` | Optional long freeze. Day-to-day releases do **not** use this branch; they use the Release workflow. |
+| `hotfix/*` | From `main`, merge to `develop`, then run Release so `main` still only moves by a tagged squash. |
+
+Classic Gitflow’s “open `release/0.3.0` and merge by hand” is replaced by the Release workflow. The Atlassian branch *names* stay in [02-Git-workflow.md](02-Git-workflow.md); the *button* that cuts a version is Actions.
+
+## Secrets
+
+| Secret | Required for | Used by |
+| --- | --- | --- |
+| *(none)* | CI, Release, Pages, GHCR push | `GITHUB_TOKEN` |
+| `DEPLOY_HOST` | SSH replace on the VM | Service Deploy |
+| `DEPLOY_USER` | SSH replace on the VM | Service Deploy |
+| `DEPLOY_SSH_KEY` | SSH private key (PEM) | Service Deploy |
+| `DEPLOY_PORT` | Optional, default `22` | Service Deploy |
+
+Set secrets with:
+
+```bash
+gh secret set DEPLOY_HOST
+gh secret set DEPLOY_USER
+gh secret set DEPLOY_SSH_KEY < deploy_key.pem
+```
+
+Do not commit keys. Do not put the VM password in the wiki.
+
+## Per-repo scripts
+
+Each repository owns four scripts. Workflows call them; they do not inline stack-specific commands.
+
+| Script | CI | Release |
+| --- | --- | --- |
+| `.github/scripts/ci/format.sh` | `--check` | `--write` |
+| `.github/scripts/ci/test.sh` | yes | yes |
+| `.github/scripts/ci/smoke.sh` | yes (after build) | yes (after build) |
+| `.github/scripts/ci/next_version.py` | no | yes |
+| `.github/scripts/ci/prepare_changelog.py` | no | yes |
+
+When application code appears, **change the scripts**, not the workflow names or triggers. The contract on this page stays.
+
+## What to say at the defense
+
+We use GitHub Actions as the only CI/CD runner. Pull requests onto `develop` always run format, tests, and a live smoke. A separate Release workflow is the only way onto `main`: it squash-merges, tags SemVer (automatic or typed in), and that tag is the deploy.

--- a/70-Engineering-practices/README.md
+++ b/70-Engineering-practices/README.md
@@ -12,6 +12,7 @@ How we write, review, and ship code and documentation across Gym Buddies reposit
 | [04-Documentation-conventions.md](04-Documentation-conventions.md) | Numbering, page template, linking, changelog entries |
 | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md) | Issues live here, must link a wiki page, commit scope = ticket id |
 | [06-Versioning.md](06-Versioning.md) | [Semantic Versioning 2.0.0](https://semver.org/) — `0.y.z` until the academic `1.0.0` |
+| [07-CI-CD.md](07-CI-CD.md) | GitHub Actions: CI on `develop`, Release squash+tag onto `main`, Deploy |
 
 These practices exist so the software-engineering module is visible in the daily workflow, not only in UML.
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -16,9 +16,11 @@ Until the first application release, versions refer to the **documentation contr
 - Tickets live on this repository (GitHub Projects), must link a wiki page, and are referenced from every other repo
 - Stack: Java 26 + Spring Boot backend, Angular 22 + TypeScript 7 frontend, PostgreSQL 18, dedicated `gym-buddy-openapi` repository (not a live `/v3/api-docs` as source of truth)
 - Hosting: GitHub Pages for this wiki, the Angular apps, and the OpenAPI UI; Java and PostgreSQL cannot run on Pages
+- Releases onto `main` are automated squash+tag commits; version numbers are computed from Conventional Commits and can be overridden by hand
 
 ### Added
 
+- CI/CD contract: GitHub Actions CI on every `develop` PR/push, a separate Release workflow that squash-merges and tags `main`, Deploy of that tag (Pages / Docker + VM)
 - Confluence-style wiki structure (`XX-Section-name`) covering the 2025/2026 compensation brief
 - Functional specifications for every overview feature
 - Technical specifications for JWT, file ACL, image storage, messaging, search, fixtures

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Top-level folders follow `XX-Section-name`, where `XX` is `00`–`99`. Numbers a
 | [40-Technical-specifications](40-Technical-specifications/README.md) | JWT, file access, image storage, messaging transport, search, fixtures, API conventions |
 | [50-Algorithms](50-Algorithms/README.md) | Friend suggestions, filtered search, user matching — with justification |
 | [60-UML-diagrams](60-UML-diagrams/README.md) | Use case, activity, sequence, and class diagrams |
-| [70-Engineering-practices](70-Engineering-practices/README.md) | Gitflow, SemVer, Conventional Commits, tickets, coding standards |
+| [70-Engineering-practices](70-Engineering-practices/README.md) | Gitflow, SemVer, Conventional Commits, tickets, CI/CD |
 | [80-Testing](80-Testing/README.md) | Test plan, unit / integration / functional tests, fixture strategy |
 | [90-Changelog](90-Changelog/README.md) | Version history for the product and for this wiki |
 | [91-Critical-analysis](91-Critical-analysis/README.md) | Critique of the solution and possible improvements |


### PR DESCRIPTION
Refs: Projet-de-compensation-2025-2026/gym-buddy-documentation#1

Implements the contract in ``70-Engineering-practices/07-CI-CD.md``.

- CI on every PR and push to ``develop`` (format, tests, live Jekyll smoke)
- Separate Release workflow: format → test → smoke → squash-merge onto ``main`` → tag ``vX.Y.Z``
- Version automatic from Conventional Commits, overridable by hand; ``1.0.0`` never automatic
- Deploy of that tag to GitHub Pages