### PR TITLE
Add feature implementation workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -7,8 +7,12 @@ body:
     attributes:
       value: |
         Tickets live in **gym-buddy-documentation**. Every ticket must point at a wiki page
-        (functional spec, technical spec, algorithm, architecture, test plan, …).
-        See `70-Engineering-practices/05-Tickets-and-GitHub-projects.md`.
+        (functional spec, technical spec, algorithm, architecture, test plan, …)
+        and must be attached to the singular **Gym Buddy Project**.
+        Fill every field. New tickets default to **Not Ready**; only Joaquim Kéloglanian
+        moves them to **Todo** after an explicit review.
+        See `70-Engineering-practices/08-Feature-implementation.md`
+        and `70-Engineering-practices/05-Tickets-and-GitHub-projects.md`.
   - type: dropdown
     id: type
     attributes:

--- a/10-Getting-started/01-How-to-use-this-wiki.md
+++ b/10-Getting-started/01-How-to-use-this-wiki.md
@@ -25,6 +25,7 @@ Leave gaps (this tree already does: 00, 10, 20, …) so a new top-level section 
 | “Why this algorithm?” | [../50-Algorithms](../50-Algorithms/README.md) |
 | A diagram for the report | [../60-UML-diagrams](../60-UML-diagrams/README.md) |
 | How to open a PR | [../70-Engineering-practices](../70-Engineering-practices/README.md) |
+| How to take a feature from spec to `develop` | [../70-Engineering-practices/08-Feature-implementation.md](../70-Engineering-practices/08-Feature-implementation.md) |
 
 ## Page contract
 

--- a/70-Engineering-practices/02-Git-workflow.md
+++ b/70-Engineering-practices/02-Git-workflow.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Approved |
-| Related | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md), [06-Versioning.md](06-Versioning.md), [07-CI-CD.md](07-CI-CD.md) |
+| Related | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md), [06-Versioning.md](06-Versioning.md), [07-CI-CD.md](07-CI-CD.md), [08-Feature-implementation.md](08-Feature-implementation.md) |
 
 Gym Buddies follows the **Gitflow** branching model as documented by Atlassian:
 
@@ -95,6 +95,7 @@ Product and specification work should still start from a ticket. Ticket-less com
 ## Pull requests
 
 - Open the PR against `develop`. Never against `main` (Release owns `main`; see [07-CI-CD.md](07-CI-CD.md))
+- The ticket on **Gym Buddy Project** is `In Progress` for the life of the PR and becomes `Done` only after the merge to `develop` ([08-Feature-implementation.md](08-Feature-implementation.md))
 - Title includes the ticket when there is one: `[#42] Reject accept when the event is full`
 - Description links the ticket and the wiki page the ticket already points at
 - Review checklist: [03-Review-process.md](03-Review-process.md)

--- a/70-Engineering-practices/03-Review-process.md
+++ b/70-Engineering-practices/03-Review-process.md
@@ -3,12 +3,14 @@
 | Field | Value |
 | --- | --- |
 | Status | Proposed |
+| Related | [08-Feature-implementation.md](08-Feature-implementation.md), [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md) |
 
 Even on an individual project, every merge to `develop` (features) or `main` (releases / hotfixes) gets a **self-review checklist**. Treat it as the Software Engineering module’s process evidence.
 
 ## Checklist
 
-- [ ] Ticket exists on `gym-buddy-documentation` and **links a wiki page** ([05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md)) — or the commit has **no** ticket id in the scope
+- [ ] Ticket exists on `gym-buddy-documentation`, is on **Gym Buddy Project**, and **links a wiki page** ([05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md), [08-Feature-implementation.md](08-Feature-implementation.md)) — or the commit has **no** ticket id in the scope
+- [ ] Ticket is `In Progress` while the PR is open; it becomes `Done` only after the merge to `develop`
 - [ ] Commit scopes follow [02-Git-workflow.md](02-Git-workflow.md): `(#42)` if there is a ticket, topical otherwise
 - [ ] `Refs: <owner>/gym-buddy-documentation#<id>` in the commit/PR body when a ticket exists
 - [ ] Spec IDs in the description (`FS-…`, `TS-…`)

--- a/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
+++ b/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
@@ -3,9 +3,11 @@
 | Field | Value |
 | --- | --- |
 | Status | Approved |
-| Related | [02-Git-workflow.md](02-Git-workflow.md) |
+| Related | [02-Git-workflow.md](02-Git-workflow.md), [08-Feature-implementation.md](08-Feature-implementation.md) |
 
-Work is tracked as **GitHub Issues**, organized on a **GitHub Project**. The Project is the board; the Issue is the ticket.
+Work is tracked as **GitHub Issues**, organized on the singular GitHub Project [**Gym Buddy Project**](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1). The Project is the board; the Issue is the ticket. Do not create a second project.
+
+When a feature is implemented from a specification, follow [08-Feature-implementation.md](08-Feature-implementation.md) first (consult Joaquim Kéloglanian, update the specs, then open the ticket).
 
 ## Where tickets live
 
@@ -17,7 +19,7 @@ Reasons:
 - One sequence of ids (`#1`, `#2`, …) is shared across all implementation repos
 - Commits in other repos can still link here with `Refs: <owner>/gym-buddy-documentation#42`
 
-The GitHub Project (board columns such as Backlog / Ready / In progress / In review / Done) is attached to this repository or to the GitHub organization, and it includes issues from this repo.
+**Gym Buddy Project** is the only board. Every ticket opened from the template is attached to it. New items default to `Not Ready`. The four statuses and who may change them are defined in [08-Feature-implementation.md](08-Feature-implementation.md).
 
 ## Mandatory ticket contents
 
@@ -56,14 +58,17 @@ A ticket may produce many commits (spec tweak, OpenAPI, backend, tests, frontend
 
 If there is no ticket, **do not** put a ticket number in the commit scope. Use a topical scope (`wiki`, `ci`, `deps`). Do not create dummy issues after the fact just to decorate a typo-fix unless you want the board to show it.
 
-## Suggested board columns
+## Board statuses
 
-| Column | Meaning |
+Exactly four. These replace any older Backlog / Ready / In review layout.
+
+| Status | Meaning |
 | --- | --- |
-| Backlog | Idea; wiki page may still be Draft |
-| Ready | Wiki link present, acceptance clear |
-| In progress | A `feature/<id>-…` branch exists |
-| In review | PR against `develop` |
-| Done | Merged to `develop` (or to `main` for a hotfix) |
+| `Not Ready` | Default at creation. Specs and template are filled; Joaquim has not green-lit implementation |
+| `Todo` | Joaquim Kéloglanian has read, reviewed, and explicitly approved the ticket |
+| `In Progress` | Implementation of this ticket has started |
+| `Done` | Implemented, tested, formatted, and merged into `develop` |
 
-The academic ship (`1.0.0`) is a **release**, not a ticket column. Tickets close when their change is on `develop`; the release branch packages them.
+Rules and the full feature sequence: [08-Feature-implementation.md](08-Feature-implementation.md).
+
+The academic ship (`1.0.0`) is a **release**, not a ticket status. Tickets become `Done` on `develop`; Release packages them.

--- a/70-Engineering-practices/08-Feature-implementation.md
+++ b/70-Engineering-practices/08-Feature-implementation.md
@@ -1,0 +1,118 @@
+# Feature implementation workflow
+
+| Field | Value |
+| --- | --- |
+| Status | Approved |
+| Related | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md), [03-Review-process.md](03-Review-process.md), [02-Git-workflow.md](02-Git-workflow.md), [07-CI-CD.md](07-CI-CD.md), [../30-Functional-specifications/00-Conventions.md](../30-Functional-specifications/00-Conventions.md) |
+
+How a feature goes from an idea in the assignment (or a later request) to a merge on `develop`. This page is the process. Ticket fields live in [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md). Git and CI rules stay on their own pages.
+
+The product owner is **Joaquim Kéloglanian**. No ticket moves to `Todo`, and no implementation starts, without his explicit green light.
+
+## Sequence
+
+```mermaid
+flowchart TD
+  consult[1. Consult Joaquim Kéloglanian]
+  mature[2. Feature matures]
+  specs[3. Update functional and technical specifications]
+  ticket[4. Open a ticket from the template]
+  notReady[Status: Not Ready]
+  review[Joaquim reads, reviews, green-lights]
+  todo[Status: Todo]
+  start[5. Implementation starts]
+  inProgress[Status: In Progress]
+  land[6. Implemented, tested, formatted, merged to develop]
+  done[Status: Done]
+
+  consult --> mature --> specs --> ticket --> notReady
+  notReady --> review --> todo --> start --> inProgress --> land --> done
+```
+
+### 1. Consult Joaquim Kéloglanian
+
+The first step is always a conversation with Joaquim. Scope, what “done” looks like, and which wiki pages will own the feature are decided here — not invented in a ticket.
+
+Do not open a ticket in this step. Do not start a `feature/*` branch.
+
+### 2. Let the feature mature
+
+Keep talking until the feature is concrete enough to write as requirements: actors, rules, errors, and what a test would assert. If it is still a sketch, stay here.
+
+### 3. Update the specifications
+
+Once the feature has matured, **write or update the wiki first**:
+
+| Kind of change | Where it lands |
+| --- | --- |
+| What the product does | [30-Functional-specifications](../30-Functional-specifications/README.md) (`FS-…` requirements) |
+| How it is built | [40-Technical-specifications](../40-Technical-specifications/README.md) (`TS-…` when they exist) |
+| Algorithm to justify | [50-Algorithms](../50-Algorithms/README.md) |
+| Shape of the system | [20-Architecture](../20-Architecture/README.md) |
+| HTTP surface | [40-Technical-specifications/08-OpenAPI-contract.md](../40-Technical-specifications/08-OpenAPI-contract.md) — the YAML itself stays in `gym-buddy-openapi` |
+
+A ticket that points at a missing or stale spec is invalid. Change the spec in this repository, then open the ticket.
+
+### 4. Create the ticket
+
+Open a GitHub Issue on **`gym-buddy-documentation`** using the existing template [`.github/ISSUE_TEMPLATE/ticket.yml`](../../.github/ISSUE_TEMPLATE/ticket.yml). Fill **every** field. An empty optional-looking box is not optional here.
+
+| Template field | What to put |
+| --- | --- |
+| Title | `[GB] ` plus one imperative outcome |
+| Type | Feature, Bug, Chore, or Docs |
+| Documentation page | Relative path(s) in **this** wiki. Required. Example: `30-Functional-specifications/07-Events.md`. Add the matching technical page when one exists. |
+| Spec IDs | `FS-…` / `TS-…` from those pages |
+| Implementation repository | Every repo that will change (`gym-buddy-documentation`, `gym-buddy-service`, `gym-buddy-ui`, `gym-buddy-openapi`) |
+| Acceptance | Checklist copied or cited from the linked spec |
+
+The ticket **must** point at the documentation it implements. A title such as “implement events” with no wiki path is incomplete — go back to step 3.
+
+The ticket **must** be attached to the existing, singular GitHub Project [**Gym Buddy Project**](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1). Do not create a second project. Do not leave the issue sitting only in the repo issues list.
+
+Newly created tickets default to **`Not Ready`**.
+
+## Statuses
+
+There are exactly four. They are the Status field on **Gym Buddy Project**. Do not invent extra columns (`Backlog`, `Ready`, `In review`, …).
+
+| Status | Meaning | Who may set it |
+| --- | --- | --- |
+| `Not Ready` | Ticket exists, every template field is filled, it is on **Gym Buddy Project**, and it points at wiki pages. It is **not** approved for implementation. | Default at creation |
+| `Todo` | Joaquim Kéloglanian has **explicitly** read the ticket, reviewed the linked specs, and given the green light | **Only** Joaquim, after that review |
+| `In Progress` | Implementation of this ticket has started (branch, first commit, or first draft PR) | Whoever starts the work, **as soon as** it starts |
+| `Done` | The change is implemented, tested, formatted, and **merged into `develop`** | After the merge to `develop` (CI green — see [07-CI-CD.md](07-CI-CD.md)) |
+
+### `Not Ready` → `Todo`
+
+Filling the template is not a green light. `Todo` is set **only** when Joaquim has:
+
+1. Read the ticket
+2. Reviewed the linked documentation
+3. Said explicitly that implementation may start
+
+Nobody else promotes a ticket to `Todo`. A verbal “looks fine, go” in the consult (step 1) does **not** skip this review: that consult happens *before* the specs and the ticket exist.
+
+### `Todo` → `In Progress`
+
+Set `In Progress` the moment work on the ticket begins. Do not leave a live `feature/<id>-…` branch on `Todo`.
+
+Implementation still follows [02-Git-workflow.md](02-Git-workflow.md): branch from `develop`, PR back to `develop`, commit scope `(#<id>)`, `Refs: Projet-de-compensation-2025-2026/gym-buddy-documentation#<id>`.
+
+### `In Progress` → `Done`
+
+A ticket becomes `Done` when **all** of these are true:
+
+1. The behaviour in the linked spec is implemented
+2. Tests required by that spec (and [80-Testing](../80-Testing/README.md)) exist and pass
+3. Format checks pass (CI `format` / [07-CI-CD.md](07-CI-CD.md))
+4. The PR is merged into **`develop`**
+
+A green CI run on an open PR is not `Done`. A squash onto `main` (a Release) is not what closes the ticket. Tickets close on `develop`; Release packages whatever is already there.
+
+## What this page does not replace
+
+- Ticket field rules: [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md)
+- Branch names and commit messages: [02-Git-workflow.md](02-Git-workflow.md)
+- PR checklist: [03-Review-process.md](03-Review-process.md)
+- How `develop` is proven and how `main` is tagged: [07-CI-CD.md](07-CI-CD.md)

--- a/70-Engineering-practices/README.md
+++ b/70-Engineering-practices/README.md
@@ -13,6 +13,7 @@ How we write, review, and ship code and documentation across Gym Buddies reposit
 | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md) | Issues live here, must link a wiki page, commit scope = ticket id |
 | [06-Versioning.md](06-Versioning.md) | [Semantic Versioning 2.0.0](https://semver.org/) — `0.y.z` until the academic `1.0.0` |
 | [07-CI-CD.md](07-CI-CD.md) | GitHub Actions: CI on `develop`, Release squash+tag onto `main`, Deploy |
+| [08-Feature-implementation.md](08-Feature-implementation.md) | Consult Joaquim → update specs → ticket on **Gym Buddy Project** → `Not Ready` / `Todo` / `In Progress` / `Done` |
 
 These practices exist so the software-engineering module is visible in the daily workflow, not only in UML.
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -13,13 +13,15 @@ Until the first application release, versions refer to the **documentation contr
 
 - Engineering practices now follow [Gitflow (Atlassian)](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) and [SemVer 2.0.0](https://semver.org/); `1.0.0` is the compensation-project ship, earlier tags stay on `0.y.z`
 - Commits that implement a GitHub Issue use the ticket id as the Conventional Commits scope; ticket-less commits must not invent one
-- Tickets live on this repository (GitHub Projects), must link a wiki page, and are referenced from every other repo
+- Tickets live on this repository, attach to the singular **Gym Buddy Project**, must link a wiki page, and are referenced from every other repo
+- Feature work follows consult → specs → ticket: statuses are `Not Ready`, `Todo` (Joaquim’s green light only), `In Progress`, and `Done` (merged to `develop`)
 - Stack: Java 26 + Spring Boot backend, Angular 22 + TypeScript 7 frontend, PostgreSQL 18, dedicated `gym-buddy-openapi` repository (not a live `/v3/api-docs` as source of truth)
 - Hosting: GitHub Pages for this wiki, the Angular apps, and the OpenAPI UI; Java and PostgreSQL cannot run on Pages
 - Releases onto `main` are automated squash+tag commits; version numbers are computed from Conventional Commits and can be overridden by hand
 
 ### Added
 
+- Feature implementation workflow: consult Joaquim Kéloglanian, update functional and technical specs, then open a fully filled ticket on **Gym Buddy Project**
 - CI/CD contract: GitHub Actions CI on every `develop` PR/push, a separate Release workflow that squash-merges and tags `main`, Deploy of that tag (Pages / Docker + VM). Private-repo Pages and branch-protection need GitHub Pro or a public repo.
 - Confluence-style wiki structure (`XX-Section-name`) covering the 2025/2026 compensation brief
 - Functional specifications for every overview feature

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Top-level folders follow `XX-Section-name`, where `XX` is `00`–`99`. Numbers a
 | [40-Technical-specifications](40-Technical-specifications/README.md) | JWT, file access, image storage, messaging transport, search, fixtures, API conventions |
 | [50-Algorithms](50-Algorithms/README.md) | Friend suggestions, filtered search, user matching — with justification |
 | [60-UML-diagrams](60-UML-diagrams/README.md) | Use case, activity, sequence, and class diagrams |
-| [70-Engineering-practices](70-Engineering-practices/README.md) | Gitflow, SemVer, Conventional Commits, tickets, CI/CD |
+| [70-Engineering-practices](70-Engineering-practices/README.md) | Gitflow, SemVer, Conventional Commits, tickets, feature workflow, CI/CD |
 | [80-Testing](80-Testing/README.md) | Test plan, unit / integration / functional tests, fixture strategy |
 | [90-Changelog](90-Changelog/README.md) | Version history for the product and for this wiki |
 | [91-Critical-analysis](91-Critical-analysis/README.md) | Critique of the solution and possible improvements |


### PR DESCRIPTION
Merges the remaining documentation work onto ``develop`` so the first Pages release includes:

- ``70-Engineering-practices/08-Feature-implementation.md``
- Ticket statuses ``Not Ready`` / ``Todo`` / ``In Progress`` / ``Done``
- Link to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1)

The earlier feature branches ``feature/1-ci-pipeline`` and ``feature/1-ci-cd-free-plan-note`` are already merged (PRs #2 and #3).