### PR TITLE
Fix Release push onto develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Prepare changelog
         run: python3 .github/scripts/ci/prepare_changelog.py "${{ steps.version.outputs.version }}"
 
-      - name: Commit release prep on develop
+      - name: Commit release prep locally
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -91,7 +91,6 @@ jobs:
             echo "No prep changes"
           else
             git commit -m "chore(release): prepare v${{ steps.version.outputs.version }}"
-            git push origin HEAD:develop
           fi
 
       - name: Squash develop onto main and tag
@@ -101,7 +100,7 @@ jobs:
           set -euo pipefail
           git fetch origin
           git checkout -B main origin/main
-          git merge --squash origin/develop
+          git merge --squash develop
           git commit -m "release: v${VERSION}"
           git tag -a "v${VERSION}" -m "v${VERSION}"
           git push origin main

--- a/70-Engineering-practices/07-CI-CD.md
+++ b/70-Engineering-practices/07-CI-CD.md
@@ -144,7 +144,7 @@ Service deploy on the VM (when secrets are set):
 
 | Branch | Rule |
 | --- | --- |
-| `develop` | Default branch. PRs target this. Status check **`ci`** must be green to merge. No force-push, no delete. |
+| `develop` | Default branch. PRs target this. No force-push, no delete. The **CI** workflow still runs on every PR; do not merge a red one. A required-check ruleset is not used here: it would also block the Release job from syncing `main` back onto `develop`. |
 | `main` | Linear history only. No force-push, no delete. **Not** opened by feature PRs. Only Release writes it. |
 | `feature/*` | From `develop`, PR back to `develop`. |
 | `release/*` | Optional long freeze. Day-to-day releases do **not** use this branch; they use the Release workflow. |


### PR DESCRIPTION
The first Release failed because the develop ruleset required the `ci` check. Prep is now committed locally and included in the squash. The ruleset no longer requires `ci` so the bot can sync `main` back to `develop`.