### PR TITLE
docs: complete environment, pipeline, and remaining wiki gaps

### DIFF
--- a/00-Project-brief/01-Scope-and-modules.md
+++ b/00-Project-brief/01-Scope-and-modules.md
@@ -63,15 +63,27 @@ Record any change to this list after the instructor scoping discussion.
 
 | Step from the brief | Status | Notes |
 | --- | --- | --- |
-| Discuss and scope the project with the instructor | Not done | Book this before locking the stack |
-| Write functional and technical specifications | In progress | This wiki |
-| Provide UML diagrams | In progress | [../60-UML-diagrams](../60-UML-diagrams/README.md) |
-| Design and write algorithms | In progress | [../50-Algorithms](../50-Algorithms/README.md) |
-| Implement backend, frontend, back-office | Not started | Application repositories |
-| Test plan and unit tests | Drafted | [../80-Testing](../80-Testing/README.md) |
-| Critical analysis | Drafted | [../91-Critical-analysis](../91-Critical-analysis/README.md) |
-| Justify library choices | Proposed | [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md) |
+| Discuss and scope the project with the instructor | Not done | No minutes yet — see below |
+| Write functional and technical specifications | Written (Draft until cadrage) | This wiki |
+| Provide UML diagrams | Written (Draft) | [../60-UML-diagrams](../60-UML-diagrams/README.md) |
+| Design and write algorithms | Written (Draft) | [../50-Algorithms](../50-Algorithms/README.md) |
+| Implement backend, frontend, back-office | Probe only | Python probe + CI/CD + VPS. Spring / Angular not started |
+| Test plan and unit tests | Strategy written | [../80-Testing](../80-Testing/README.md) — no application test sources yet |
+| Critical analysis | Written (pre-implementation) | [../91-Critical-analysis](../91-Critical-analysis/README.md) |
+| Justify library choices | Approved | [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md) |
+
+## How to record the instructor cadrage
+
+When the meeting happens, do **not** invent content beforehand. Add a subsection here with:
+
+1. Date and attendees
+2. Decisions that change this page (in-scope / out-of-scope)
+3. Decisions that change [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md)
+4. Anything the instructor asked to see at the defense
+5. Link to the ticket or mail thread if one exists
+
+Until that subsection exists, product pages stay **Draft**. Technical choices stay **Approved** for implementation unless the meeting overturns them.
 
 ## Non-goals for this wiki
 
-This repository does not contain application source code. It contains the decisions those repositories must follow.
+This repository does not contain application source code. It contains the decisions those repositories must follow. How to run and ship: [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md).

--- a/00-Project-brief/02-Stakeholders-and-defense.md
+++ b/00-Project-brief/02-Stakeholders-and-defense.md
@@ -9,7 +9,7 @@
 
 | Actor | Role |
 | --- | --- |
-| Student (author) | Sole implementer and maintainer. Individual project. |
+| Joaquim Kéloglanian (author) | Sole implementer and maintainer. Individual project. GitHub: Joaquim-Keloglanian |
 | Instructor ([maurras.togbe@isep.fr](mailto:maurras.togbe@isep.fr)) | Validates the topic, receives deliverables, attends the defense, must have GitHub access |
 | Member | Athlete using the product to find buddies and sessions |
 | Organizer | Member who creates events (not a separate account type) |
@@ -20,10 +20,12 @@
 
 - **Due:** 31 August 2026, no later
 - **Channel:** email the required deliverables to [maurras.togbe@isep.fr](mailto:maurras.togbe@isep.fr)
-- **GitHub:** add `maurras.togbe@isep.fr` to the private repository (**mandatory**)
+- **GitHub:** add `maurras.togbe@isep.fr` to every **private** repository (**mandatory**)
 - **Deliverables:**
-  - Report (GitHub link, screenshots, architecture, data model, UML, technical justifications, functional and technical specifications)
+  - Report (GitHub links, screenshots, architecture, data model, UML, technical justifications, functional and technical specifications)
   - PowerPoint presentation
+
+Repositories to cite: [../10-Getting-started/02-Related-repositories.md](../10-Getting-started/02-Related-repositories.md).
 
 See [../99-Academic-deliverables/01-Report-outline.md](../99-Academic-deliverables/01-Report-outline.md).
 

--- a/10-Getting-started/01-How-to-use-this-wiki.md
+++ b/10-Getting-started/01-How-to-use-this-wiki.md
@@ -26,6 +26,7 @@ Leave gaps (this tree already does: 00, 10, 20, …) so a new top-level section 
 | A diagram for the report | [../60-UML-diagrams](../60-UML-diagrams/README.md) |
 | How to open a PR | [../70-Engineering-practices](../70-Engineering-practices/README.md) |
 | How to take a feature from spec to `develop` | [../70-Engineering-practices/08-Feature-implementation.md](../70-Engineering-practices/08-Feature-implementation.md) |
+| How to run locally / ship to the VPS | [04-Environment-and-pipeline.md](04-Environment-and-pipeline.md) |
 
 ## Page contract
 

--- a/10-Getting-started/02-Related-repositories.md
+++ b/10-Getting-started/02-Related-repositories.md
@@ -3,16 +3,18 @@
 | Field | Value |
 | --- | --- |
 | Status | Approved |
-| Related | [../20-Architecture/01-Software-architecture.md](../20-Architecture/01-Software-architecture.md), [../20-Architecture/08-Hosting-and-GitHub-Pages.md](../20-Architecture/08-Hosting-and-GitHub-Pages.md) |
+| Related | [../20-Architecture/01-Software-architecture.md](../20-Architecture/01-Software-architecture.md), [../20-Architecture/08-Hosting-and-GitHub-Pages.md](../20-Architecture/08-Hosting-and-GitHub-Pages.md), [04-Environment-and-pipeline.md](04-Environment-and-pipeline.md) |
 
-Gym Buddies is documented **once** here and implemented in **three** other repositories. Names below are the intended layout; replace the GitHub URLs when each repo exists.
+Gym Buddies is documented **once** here and implemented in **three** other repositories.
 
-| Repository | Responsibility | Hosted on |
-| --- | --- | --- |
-| `gym-buddy-documentation` (this repo) | Product, architecture, specs, practices, academic packaging, **tickets** | GitHub Pages (Markdown → Jekyll) |
-| `gym-buddy-openapi` | Versioned OpenAPI 3 contract + static Swagger/Redoc | GitHub Pages (static) |
-| `gym-buddy-service` | Java API, domain, jobs, WebSocket, fixtures | **Not** Pages — always-on host |
-| `gym-buddy-ui` | Angular member app **and** Angular back-office | GitHub Pages (static `ng build`) |
+| Repository | URL | Visibility | Responsibility | Hosted on |
+| --- | --- | --- | --- | --- |
+| `gym-buddy-documentation` (this repo) | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation | Public | Product, architecture, specs, practices, academic packaging, **tickets** | GitHub Pages (Markdown → Jekyll) |
+| `gym-buddy-openapi` | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi | Private | Versioned OpenAPI 3 contract + static Swagger/Redoc | GitHub Pages when the plan allows (static) |
+| `gym-buddy-service` | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service | Private | Java API, domain, jobs, WebSocket, fixtures (Python probe until Spring exists) | OVH VPS — see [04-Environment-and-pipeline.md](04-Environment-and-pipeline.md) |
+| `gym-buddy-ui` | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-ui | Private | Angular member app **and** Angular back-office | GitHub Pages (static `ng build`) |
+
+Default branch on every repository: **`develop`**. Feature work never targets `main`.
 
 The instructor account [maurras.togbe@isep.fr](mailto:maurras.togbe@isep.fr) must be a collaborator on every **private** repository.
 
@@ -27,20 +29,24 @@ The contract is a **git artifact**, not a runtime accident:
 
 Spring may still expose `/v3/api-docs` in development as a convenience. That endpoint is **not** the source of truth. If it disagrees with `gym-buddy-openapi`, the repository wins.
 
+Today the OpenAPI repo is a stub (`GET /api/v1/health` only). Target health paths are `/api/v1/healthz` and `/api/v1/readyz` — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md).
+
 ## Rules for application repos
 
 1. Do not copy functional specs into application trees. Link to `30-Functional-specifications`.
 2. Do not hand-edit generated clients; change the OpenAPI repo and regenerate.
 3. Tickets live in **this** documentation repo and must link to a wiki page ([../70-Engineering-practices/05-Tickets-and-GitHub-projects.md](../70-Engineering-practices/05-Tickets-and-GitHub-projects.md)).
-4. The report cites all four repositories.
+4. The report cites all four repositories using the URLs in the table above.
 
 ## Local development picture
 
 ```
 gym-buddy-documentation/     ← you are here (wiki + GitHub Project)
 gym-buddy-openapi/           ← HTTP contract
-gym-buddy-service/           ← Java 26 + Spring Boot
+gym-buddy-service/           ← Java 26 + Spring Boot (probe image until then)
 gym-buddy-ui/                ← Angular 22 (member + back-office)
 ```
 
-A compose file in the backend repo starts PostgreSQL 18, MinIO, Redis, and the API. The Angular apps point at that API. OpenAPI files are consumed as a git submodule, a published npm/Maven package, or a raw tagged URL — pick one in the backend README and stick to it.
+A compose file in the backend repo will start PostgreSQL 18, MinIO, Redis, and the API. The Angular apps point at `http://localhost:8080/api/v1`. OpenAPI files are consumed as a git submodule, a published package, or a raw tagged URL — pick one in the backend README and stick to it.
+
+How to run it, which ports to bind, and how a release reaches the VPS: [04-Environment-and-pipeline.md](04-Environment-and-pipeline.md).

--- a/10-Getting-started/03-Glossary.md
+++ b/10-Getting-started/03-Glossary.md
@@ -22,9 +22,15 @@
 | Suggestion | System-proposed member the user does not already follow as a friend |
 | Matching | Pairing members with events or with other members for a session |
 | Fixture | Generated data used in development and tests (thousands of rows) |
+| Datafaker | Java library used to generate fixtures with seed `FIXTURE_SEED=20260813` |
 | Back-office | Staff UI for admins and moderators |
 | Controlled file | Any stored blob (image, audio) reachable only after authorization |
 | JWT | JSON Web Token used as the access credential |
+| healthz | `GET /api/v1/healthz` — process is up (unauthenticated) |
+| readyz | `GET /api/v1/readyz` — PostgreSQL and object storage are reachable |
+| Caddy | Reverse proxy on the VPS; terminates HTTPS and forwards to `127.0.0.1:8080` |
+| Compose (local) | Laptop `compose.yaml` in `gym-buddy-service`: Postgres 18, Redis, MinIO, API |
+| VM replace | `replace.sh` on the VPS: `docker run` of the API image on loopback, not compose |
 | CI | Continuous integration: format, tests, and a live smoke on every `develop` PR |
 | Release | Dedicated workflow that squash-merges `develop` onto `main` and tags SemVer |
 | Deploy | What happens after that tag: Pages and/or Docker on the VM |

--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -1,0 +1,212 @@
+# Environment and pipeline
+
+| Field | Value |
+| --- | --- |
+| Status | Approved |
+| Related | [02-Related-repositories.md](02-Related-repositories.md), [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md), [../70-Engineering-practices/08-Feature-implementation.md](../70-Engineering-practices/08-Feature-implementation.md), [../20-Architecture/08-Hosting-and-GitHub-Pages.md](../20-Architecture/08-Hosting-and-GitHub-Pages.md) |
+
+How to run Gym Buddies locally, how a change is proven and released, and how the live API lands on the VPS. This page is the runbook. The CI/CD contract lives in [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md). Feature work still starts on the wiki: [../70-Engineering-practices/08-Feature-implementation.md](../70-Engineering-practices/08-Feature-implementation.md).
+
+## Today versus target
+
+Be honest at the defense. The pipeline and the VPS exist. Spring Boot does **not**.
+
+| Piece | Today (August 2026) | Target (locked) |
+| --- | --- | --- |
+| `gym-buddy-service` | Python 3.12 probe (`python:3.12-alpine`). Serves `probe/index.html` on port 8080. No `pom.xml`, no `compose.yaml`, no `.env.example`. Latest released tag **v0.1.1**. | Java 26 / Spring Boot modular monolith |
+| `gym-buddy-openapi` | OpenAPI 3.1.0 stub: `GET /health` under `/api/v1` | Full contract; health becomes `GET /api/v1/healthz` and `GET /api/v1/readyz` |
+| `gym-buddy-ui` | Static HTML probe | Angular 22 member app + back-office |
+| Health | Probe answers `GET /`. Smoke looks for the string `Gym Buddy`. | Unauthenticated `GET /api/v1/healthz` (liveness) and `GET /api/v1/readyz` (PostgreSQL + object storage reachable) |
+| Local data plane | Not in the service repo yet | `compose.yaml` in `gym-buddy-service` (Postgres 18, Redis, MinIO, API, optional MailHog) |
+| VM | One API container, bound to `127.0.0.1:8080`. Caddy terminates TLS. No compose on the VM. | Same API replace, plus a **private** data-plane compose on the Docker network (5432 / 6379 / 9000 not published) |
+| Production object storage | Not applicable (probe has none) | API **refuses to start** in production if S3-compatible storage is missing |
+
+Do not claim Spring, Flyway, or Actuator exist until `pom.xml` is in `gym-buddy-service`. Smoke scripts change when that file appears.
+
+## Ready-to-code checklist
+
+When Spring work starts, a laptop is ready when all of these are true:
+
+1. **JDK 26** installed (Java 25 LTS is the fallback if a library does not run on 26 — see [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md)).
+2. **Docker** and Compose v2 available.
+3. Clone the four repositories (URLs in [02-Related-repositories.md](02-Related-repositories.md)). Default branch is `develop` everywhere.
+4. Add `compose.yaml` to `gym-buddy-service` (plan below — **not in the repo today**).
+5. Copy `.env.example` to `.env` locally. Fill secrets there. Never commit `.env`.
+6. `docker compose up -d` binds every published port to `127.0.0.1`.
+7. Flyway applies the schema from [../20-Architecture/06-Data-model.md](../20-Architecture/06-Data-model.md).
+8. The OpenAPI stub in `gym-buddy-openapi` is the HTTP source of truth. Expand it **before** implementing a new route.
+9. Point the UI at `http://localhost:8080/api/v1`.
+
+Until `pom.xml` exists, the only thing you can run from the service repo is the probe image.
+
+## Local Compose (plan — implement in `gym-buddy-service`)
+
+Compose is the **local** story. It is not how the VPS runs today. Documented here so the first backend ticket can add the file without inventing ports or env names.
+
+File: `compose.yaml` at the root of [gym-buddy-service](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service).
+
+| Service | Image role | Host bind | Port |
+| --- | --- | --- | --- |
+| API | Spring Boot (today: the probe image) | `127.0.0.1` | `8080` |
+| PostgreSQL | **18** (not 19) | `127.0.0.1` | `5432` |
+| Redis | Cache / refresh denylist | `127.0.0.1` | `6379` |
+| MinIO | S3 API | `127.0.0.1` | `9000` |
+| MinIO console | Local admin UI | `127.0.0.1` | `9001` |
+| MailHog (optional) | SMTP catcher | `127.0.0.1` | SMTP `1025`, UI `8025` |
+
+Bind `127.0.0.1` on every published port. Do not publish the data plane to `0.0.0.0`.
+
+### Environment catalog (keys only)
+
+Values live in a local `.env` that is **not** committed. This table is names and purpose only.
+
+| Key | Where | Purpose |
+| --- | --- | --- |
+| `DATABASE_URL` | Local / later VM data plane | PostgreSQL 18 connection |
+| `REDIS_URL` | Local / later VM data plane | Cache, refresh denylist, rate limits |
+| `JWT_ACCESS_SECRET` | Local / VM | HS256 signing secret for access tokens |
+| `S3_ENDPOINT` | Local MinIO / later production bucket | S3-compatible API URL |
+| `S3_BUCKET` | Local / production | Bucket name |
+| `S3_ACCESS_KEY` | Local / production | Object-store access key |
+| `S3_SECRET_KEY` | Local / production | Object-store secret key |
+| `S3_REGION` | Local / production | Region string the client library expects |
+| `FIXTURE_SEED` | Local / CI fixtures | Fixed seed `20260813` |
+| `SPRING_PROFILES_ACTIVE` | Local / VM | `local` / `test` / `prod`. Production refuses to start without object storage. |
+| `DEPLOY_HOST` | GitHub Actions only | SSH host for service Deploy |
+| `DEPLOY_USER` | GitHub Actions only | SSH user |
+| `DEPLOY_SSH_KEY` | GitHub Actions only | SSH private key (PEM) |
+| `DEPLOY_PORT` | GitHub Actions only, optional | SSH port, default `22` |
+| `DEPLOY_BIND` | VM replace script, optional | Container publish address, default `127.0.0.1` |
+
+Do not put JWT values, key material, or demo passwords in this wiki.
+
+### Demo users
+
+These handles always exist after a local fixture seed. Passwords live in the local `.env` only.
+
+| Handle | Role |
+| --- | --- |
+| `demo.alex` | member |
+| `demo.blake` | member, friend of alex |
+| `demo.mod` | moderator |
+| `demo.admin` | admin |
+
+Flyway migrations implement [../20-Architecture/06-Data-model.md](../20-Architecture/06-Data-model.md). Fixture generation uses **Datafaker** with `FIXTURE_SEED=20260813` — [../40-Technical-specifications/07-Test-fixtures.md](../40-Technical-specifications/07-Test-fixtures.md).
+
+### Production refuse-without-S3
+
+When `SPRING_PROFILES_ACTIVE=prod`, the API must exit on startup if `S3_ENDPOINT` / `S3_BUCKET` / credentials are missing. Falling back to a local `uploads/` directory is forbidden. That is the assignment’s “do not fill local storage” rule.
+
+## Pipeline (`gym-buddy-service`)
+
+Read from the live workflows on `develop` (August 2026). The public documentation repo uses the same **three names** (CI / Release / Deploy) but Deploy publishes GitHub Pages, not a container. Both models are written in [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md).
+
+| Workflow | File | Trigger | What it does |
+| --- | --- | --- | --- |
+| **CI** | `.github/workflows/ci.yml` | `pull_request` and `push` to `develop` only. **No** `workflow_dispatch`. | Format `--check`, tests, smoke. Never publishes. |
+| **Release** | `.github/workflows/release.yml` | **`workflow_dispatch` only**. Inputs: optional `version`, `bump` (`auto` / `patch` / `minor` / `major`). | Format `--write`, tests, smoke, compute SemVer, move changelog, commit prep on `develop`, **squash-merge `develop` onto `main`**, annotated tag `vX.Y.Z`, sync `main` back to `develop`, then **calls Deploy**. |
+| **Deploy** | `.github/workflows/deploy.yml` | `workflow_call` from Release, or a `v*` tag. | Build and push `ghcr.io/projet-de-compensation-2025-2026/gym-buddy-service:vX.Y.Z` (and `:latest`). SSH to the VPS and run `deploy/replace.sh`. |
+
+Successful release used as the reference: [actions/runs/32058005982](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service/actions/runs/32058005982) (tag **v0.1.1**).
+
+Image name:
+
+```text
+ghcr.io/projet-de-compensation-2025-2026/gym-buddy-service:vX.Y.Z
+```
+
+### How to dispatch a patch release
+
+From a machine that can talk to the private service repo:
+
+```bash
+gh workflow run Release --repo Projet-de-compensation-2025-2026/gym-buddy-service -f bump=patch
+```
+
+Or pin the number:
+
+```bash
+gh workflow run Release --repo Projet-de-compensation-2025-2026/gym-buddy-service -f version=0.1.2
+```
+
+GitHub UI: **Actions → Release → Run workflow** on `develop`. There is no “release on every green push”. CI does not deploy.
+
+Release fails closed: if format, tests, or smoke fail, there is no commit on `main` and no tag.
+
+### How a deploy lands on the VPS
+
+1. Deploy logs in to GHCR as `github.actor` with `GITHUB_TOKEN`.
+2. It builds the tagged commit and pushes `:vX.Y.Z` and `:latest`.
+3. If `DEPLOY_HOST`, `DEPLOY_USER`, and `DEPLOY_SSH_KEY` are set, it copies `deploy/replace.sh` over SSH and runs it with the image name plus `GHCR_USERNAME` / `GHCR_TOKEN`.
+4. `replace.sh` logs in to `ghcr.io`, `docker pull`s the tag, stops and removes the previous container, then:
+
+```text
+docker run -d --name gym-buddy-service --restart unless-stopped \
+  -p "${DEPLOY_BIND:-127.0.0.1}:${DEPLOY_HOST_PORT:-8080}:8080" "$IMAGE"
+```
+
+That is **`docker run`**, not `docker compose up -d`. The VM does not compose the API today.
+
+`DEPLOY_BIND` defaults to `127.0.0.1`. The container is not published on a public interface. Caddy is the only process that talks to `127.0.0.1:8080`.
+
+If the three SSH secrets are missing, Deploy still pushes the image and **skips** the SSH replace (exit 0). Secret **names** only: `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`, optional `DEPLOY_PORT`.
+
+### Health smoke
+
+| When | What the smoke hits |
+| --- | --- |
+| Today (probe, no `pom.xml`) | `GET /` on the container. Body must contain `Gym Buddy`. |
+| Target (Spring + contract update) | `GET /api/v1/healthz` and `GET /api/v1/readyz`, unauthenticated. |
+
+The OpenAPI stub still documents `GET /api/v1/health`. That is a known disagreement. The locked decision is `healthz` / `readyz`. Change the stub and the smoke script in the same ticket that adds Spring.
+
+## VPS
+
+| Field | Value |
+| --- | --- |
+| Offer | OVH VPS-2 2027, Gravelines |
+| OS | Ubuntu 26.04 |
+| Hostname | `vps-c39cdf03.vps.ovh.net` |
+| HTTPS | `https://vps-c39cdf03.vps.ovh.net` (not world-readable) |
+
+### Caddy
+
+Caddy reverse-proxies the hostname to `127.0.0.1:8080` and obtains a Let’s Encrypt certificate.
+
+### UFW policy
+
+| Port | Policy |
+| --- | --- |
+| 22 | Open worldwide (SSH) |
+| 80 | Denied |
+| 8080 | Denied (the API is localhost-only) |
+| 443 | Allowed only from the operator IPv6 prefix on the VPS UFW |
+
+Do not publish the operator prefix in this public wiki.
+
+### Adding data services later
+
+When PostgreSQL, Redis, and MinIO move onto the VM, run them on the Docker network next to the API. Do **not** publish `5432`, `6379`, or `9000` on the host. The API container reaches them by Compose/Docker DNS. The public story stays: Caddy → `127.0.0.1:8080`.
+
+Local compose (laptop) and VM data-plane compose are different files with the same service names. The laptop may bind those ports to `127.0.0.1` for `psql` / Redis Insight / the MinIO console. The VM must not.
+
+### Certificate renewal
+
+Let’s Encrypt **HTTP-01** needs port **80** reachable from the world for a few seconds during issuance or renewal. Do **not** leave 80 open in UFW after the challenge.
+
+**tls-alpn-01** cannot work while 443 is firewalled from the world (only the operator IPv6 prefix is allowed). Plan renewals: open 80 briefly for HTTP-01, then deny it again. Do not switch 443 to “anywhere” just to make ALPN easier.
+
+## What still has to be implemented
+
+| Work | Where |
+| --- | --- |
+| `compose.yaml`, `.env.example`, Flyway, Spring Boot | `gym-buddy-service` |
+| Expand OpenAPI past `GET /health`; rename health to `healthz` / `readyz` | `gym-buddy-openapi` |
+| Angular 22 apps | `gym-buddy-ui` |
+| Smoke script switch from `GET /` | `.github/scripts/ci/smoke.sh` in the service repo, when `pom.xml` appears |
+| Private data-plane compose on the VPS | Operator work after the API needs a database |
+| Instructor cadrage minutes | [../00-Project-brief/01-Scope-and-modules.md](../00-Project-brief/01-Scope-and-modules.md) — still **Not done** |
+
+## Feature workflow
+
+Wiki first, ticket on this documentation repo, Joaquim sets `Todo`. Full sequence: [../70-Engineering-practices/08-Feature-implementation.md](../70-Engineering-practices/08-Feature-implementation.md).

--- a/10-Getting-started/README.md
+++ b/10-Getting-started/README.md
@@ -7,13 +7,14 @@ On-ramp for anyone opening this wiki or a Gym Buddies application repository for
 | Document | Description |
 | --- | --- |
 | [01-How-to-use-this-wiki.md](01-How-to-use-this-wiki.md) | Navigation, numbering, page template, when to edit |
-| [02-Related-repositories.md](02-Related-repositories.md) | Intended multi-repo layout and how each repo must reference this wiki |
+| [02-Related-repositories.md](02-Related-repositories.md) | The four GitHub repositories and how each must reference this wiki |
 | [03-Glossary.md](03-Glossary.md) | Shared vocabulary (feed, buddy, event, fixture, …) |
+| [04-Environment-and-pipeline.md](04-Environment-and-pipeline.md) | Local compose plan, env keys, CI/Release/Deploy, VPS + Caddy + UFW |
 
 ## Suggested first hour
 
 1. Assignment: [../00-Project-brief/ProjetDeCompensation2526.en.md](../00-Project-brief/ProjetDeCompensation2526.en.md)
-2. This section’s three pages
+2. This section’s four pages, especially the [environment runbook](04-Environment-and-pipeline.md)
 3. [../20-Architecture/01-Software-architecture.md](../20-Architecture/01-Software-architecture.md)
 4. The feature you will implement next in [../30-Functional-specifications](../30-Functional-specifications/README.md)
 

--- a/20-Architecture/01-Software-architecture.md
+++ b/20-Architecture/01-Software-architecture.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
-| Related | [02-System-context.md](02-System-context.md), [07-Technology-choices.md](07-Technology-choices.md) |
+| Status | Approved |
+| Related | [02-System-context.md](02-System-context.md), [07-Technology-choices.md](07-Technology-choices.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
 Gym Buddies is a **modular monolith** behind a single API, with two web clients. That is enough to cover Software Engineering and Web Technologies without paying a microservices tax on an individual project.
 
@@ -71,7 +71,7 @@ Modules are **bounded contexts** in one deployable. They may not import each oth
 
 ## Cross-cutting rules
 
-1. Every mutating request is authenticated except `POST /auth/register` and `POST /auth/login`.
+1. Every mutating request is authenticated except `POST /api/v1/auth/register` and `POST /api/v1/auth/login`.
 2. Every file download goes through an authorization check or a short-lived signed URL. See [../40-Technical-specifications/03-Authorization-and-file-access.md](../40-Technical-specifications/03-Authorization-and-file-access.md).
 3. Clients never receive a permanent object-store key they can guess.
 4. Background work (thumbnail, audio probe, suggestion recompute) is asynchronous.
@@ -86,4 +86,10 @@ Modules are **bounded contexts** in one deployable. They may not import each oth
 | Media | No unbounded writes to the API container disk |
 | Tenancy | Single deployment, role-based access |
 
-Physical deployment can start as Docker Compose for development and a single VM or PaaS for the defense demo.
+## Physical deployment
+
+- **Local:** Docker Compose in `gym-buddy-service` (plan — file not in the repo yet). Ports bind to `127.0.0.1`.
+- **Defense / live API:** OVH VPS `vps-c39cdf03.vps.ovh.net`. Caddy terminates HTTPS and proxies to `127.0.0.1:8080`. The API container is replaced by `replace.sh`, not compose.
+- **Static sites:** GitHub Pages (this wiki, later Angular and OpenAPI UI).
+
+Details: [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md).

--- a/20-Architecture/02-System-context.md
+++ b/20-Architecture/02-System-context.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
-| Related | [01-Software-architecture.md](01-Software-architecture.md), [../60-UML-diagrams/01-Use-cases.md](../60-UML-diagrams/01-Use-cases.md) |
+| Status | Approved |
+| Related | [01-Software-architecture.md](01-Software-architecture.md), [../60-UML-diagrams/01-Use-cases.md](../60-UML-diagrams/01-Use-cases.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
 ## System context
 
@@ -14,13 +14,17 @@ flowchart LR
   instructor([Instructor])
 
   gb[Gym Buddies]
+  caddy[Caddy on OVH VPS]
 
   email[Outbound email]
   geo[Geocoding optional]
   gh[GitHub]
+  pages[GitHub Pages]
 
-  member -->|uses web app| gb
-  staff -->|uses back-office| gb
+  member -->|uses web app| pages
+  pages -->|HTTPS API| caddy
+  caddy --> gb
+  staff -->|uses back-office| pages
   gb --> email
   gb -.-> geo
   instructor -->|reads private repos| gh
@@ -40,9 +44,11 @@ flowchart LR
 
 | System | Required at MVP? | Notes |
 | --- | --- | --- |
+| OVH VPS + Caddy | Yes for the live API | Hostname `vps-c39cdf03.vps.ovh.net`. API on loopback only. |
 | SMTP / mail provider | Yes for verification; can be MailHog in dev | Do not block local fixtures on real mail |
-| Object storage | Yes | MinIO locally, S3-compatible in deploy |
+| Object storage | Yes | MinIO locally, S3-compatible in deploy. Production refuses to start without it. |
 | Geocoding | No | Members may type a free-text place + optional lat/lng |
 | Push notifications | No | In-app + websocket is enough for the defense |
+| GitHub Pages | Yes for static artifacts | Wiki, later Angular and OpenAPI UI |
 
 GitHub is part of the **academic** system, not the runtime.

--- a/20-Architecture/03-Backend.md
+++ b/20-Architecture/03-Backend.md
@@ -2,10 +2,20 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
-| Related | [01-Software-architecture.md](01-Software-architecture.md), [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md) |
+| Status | Approved |
+| Related | [01-Software-architecture.md](01-Software-architecture.md), [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
-The backend is a single **Java 26** service (Spring Boot — see [07-Technology-choices.md](07-Technology-choices.md)) exposing HTTP and a WebSocket gateway. It **implements** the contract published in `gym-buddy-openapi`; it does not own that contract.
+The target backend is a single **Java 26** service (Spring Boot — see [07-Technology-choices.md](07-Technology-choices.md)) exposing HTTP and a WebSocket gateway. It **implements** the contract published in [`gym-buddy-openapi`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi); it does not own that contract.
+
+## Today versus target
+
+| | Today | Target |
+| --- | --- | --- |
+| Runtime | Python 3.12 probe image, `GET /` HTML | Java 26 / Spring Boot |
+| Contract | OpenAPI stub `GET /api/v1/health` | Full `/api/v1`, health `healthz` / `readyz` |
+| Data plane | None on the VPS | PostgreSQL 18, Redis, MinIO (local compose first) |
+
+Do not claim Spring is running until `pom.xml` exists in [`gym-buddy-service`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service).
 
 ## Modules
 
@@ -51,4 +61,4 @@ Use the same process and an in-process queue at first; extract a worker process 
 
 ## Configuration
 
-All secrets come from the environment (`JWT_ACCESS_SECRET`, `S3_*`, `DATABASE_URL`). The API must refuse to start in production if object storage is missing — falling back to local disk is forbidden in production (assignment: do not fill local storage).
+All secrets come from the environment (`JWT_ACCESS_SECRET`, `S3_*`, `DATABASE_URL`, `REDIS_URL`). The API must refuse to start in production if object storage is missing — falling back to local disk is forbidden in production (assignment: do not fill local storage). Env catalog: [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md).

--- a/20-Architecture/04-Frontend.md
+++ b/20-Architecture/04-Frontend.md
@@ -2,10 +2,19 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
-| Related | [05-Back-office.md](05-Back-office.md), [../30-Functional-specifications](../30-Functional-specifications/README.md) |
+| Status | Approved |
+| Related | [05-Back-office.md](05-Back-office.md), [../30-Functional-specifications](../30-Functional-specifications/README.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
-The member frontend is the athlete-facing web app: **Angular 22** + **TypeScript 7.0** ([07-Technology-choices.md](07-Technology-choices.md)). It talks to the backend through a client **generated from** `gym-buddy-openapi`. The static build is eligible for GitHub Pages ([08-Hosting-and-GitHub-Pages.md](08-Hosting-and-GitHub-Pages.md)).
+The member frontend is the athlete-facing web app: **Angular 22** + **TypeScript 7.0** ([07-Technology-choices.md](07-Technology-choices.md)). It talks to the backend through a client **generated from** [`gym-buddy-openapi`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi). The static build is eligible for GitHub Pages ([08-Hosting-and-GitHub-Pages.md](08-Hosting-and-GitHub-Pages.md)).
+
+Today `gym-buddy-ui` is a static HTML probe. Angular work has not started.
+
+## API base URL
+
+| Environment | `apiBaseUrl` |
+| --- | --- |
+| Local | `http://localhost:8080/api/v1` |
+| Live (operator network) | `https://vps-c39cdf03.vps.ovh.net/api/v1` once Spring exists |
 
 ## Surfaces
 

--- a/20-Architecture/08-Hosting-and-GitHub-Pages.md
+++ b/20-Architecture/08-Hosting-and-GitHub-Pages.md
@@ -3,9 +3,9 @@
 | Field | Value |
 | --- | --- |
 | Status | Approved |
-| Related | [07-Technology-choices.md](07-Technology-choices.md), [../10-Getting-started/02-Related-repositories.md](../10-Getting-started/02-Related-repositories.md) |
+| Related | [07-Technology-choices.md](07-Technology-choices.md), [../10-Getting-started/02-Related-repositories.md](../10-Getting-started/02-Related-repositories.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
-Goal: put as much of Gym Buddies as possible on **GitHub Pages**, including this documentation.
+Goal: put as much of Gym Buddies as possible on **GitHub Pages**, including this documentation. The Java API and its data plane run on an OVH VPS.
 
 ## What GitHub Pages actually is
 
@@ -21,7 +21,7 @@ That constraint decides what can live on Pages and what cannot.
 | Member frontend (Angular) | **Yes** | `ng build` emits static files. Deploy the `dist/` folder to Pages (project site or `gh-pages` branch / Actions). |
 | Back-office (Angular, same frontend repo) | **Yes** | Second configuration / `baseHref`, same static model. |
 | OpenAPI contract + reference UI | **Yes** | Host the YAML/JSON plus a static [Swagger UI](https://swagger.io/tools/swagger-ui/) or Redoc build in `gym-buddy-openapi`. |
-| Java backend | **No** | Needs a process (Spring Boot). Pages cannot run it. |
+| Java backend | **No** | Needs a process (Spring Boot). Pages cannot run it. Lives on the OVH VPS. |
 | PostgreSQL | **No** | Needs a database engine. Pages cannot run it. |
 | MinIO / object storage | **No** | Same reason. |
 | WebSockets / JWT login against a real API | **No**, not on Pages itself | The Angular app on Pages **calls** an API hosted elsewhere. |
@@ -48,7 +48,7 @@ GitHub Pages + Jekyll already understands a Markdown wiki if we enable the offic
 2. GitHub → this repo → **Settings → Pages**.
 3. Source: **Deploy from a branch**, branch `main`, folder `/ (root)`.
 4. Wait for the Action / Pages build.
-5. Site URL will be `https://<owner>.github.io/gym-buddy-documentation/` for a project site.
+5. Project-site URL: `https://projet-de-compensation-2025-2026.github.io/gym-buddy-documentation/`
 
 **Private repositories:** Pages can be published, but visibility depends on the plan. GitHub Free makes Pages sites public even if the repo is private. A private site needs GitHub Team/Enterprise (the [Student Developer Pack](https://education.github.com/pack) often includes this). The instructor still needs GitHub access to the **repo**; Pages is for reading the wiki in a browser.
 
@@ -57,37 +57,43 @@ If the first build fails on Mermaid or a plugin, use **GitHub Actions** (`action
 ## Frontend on Pages
 
 - Build with a production `baseHref` of `/gym-buddy-ui/` (project site) or a custom domain
-- Environment: `apiBaseUrl` pointing at the **real** backend, not at Pages
+- Environment: `apiBaseUrl` pointing at the **real** backend (`https://vps-c39cdf03.vps.ovh.net/api/v1` once Spring exists), not at Pages
 - CORS on the backend must allow the Pages origin
 - Cookies (`SameSite`, `Secure`) must match HTTPS Pages
 
-## Backend and database (not Pages)
+## Backend and database (OVH VPS)
 
-Host them next to GitHub, not on Pages. Reasonable student options:
+Chosen host: **OVH VPS-2 2027** in Gravelines, Ubuntu 26.04, hostname `vps-c39cdf03.vps.ovh.net`.
 
-| Need | Options |
+Rejected for the API (fine as notes, not the plan): Render, Fly.io, Railway as the primary runtime. They hide the VM the pipeline already deploys to.
+
+| Need | Where |
 | --- | --- |
-| Java API | [Render](https://render.com/), [Fly.io](https://fly.io/), [Railway](https://railway.app/), Azure / a small VPS |
-| PostgreSQL 18 | [Neon](https://neon.tech/), [Supabase](https://supabase.com/), Railway, Azure Database for PostgreSQL, or the same host as the API |
-| Object storage | Cloudflare R2, AWS S3, or MinIO on the same VM |
+| Java API (probe today) | Docker on the VPS, bound to `127.0.0.1:8080` |
+| HTTPS | Caddy on the hostname → loopback `:8080`, Let’s Encrypt |
+| PostgreSQL 18 / Redis / MinIO | Local compose first. On the VPS later: private Docker network, ports not published |
+| Public `:8080` | Never. UFW denies it. |
 
-GitHub Actions is the only pipeline: CI on `develop`, a separate Release job onto `main`, then Deploy. Details: [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md).
+UFW: 22 open; 80 denied except during certificate HTTP-01; 443 allowed only from the operator IPv6 prefix configured on the server (the prefix is not written in this public wiki); 8080 denied.
 
-A tagged squash commit on `main` **is** the deploy. Static repos (this wiki, Angular, OpenAPI UI) go to GitHub Pages. `gym-buddy-service` builds a Docker image to GHCR and, when `DEPLOY_*` secrets exist, replaces the container on the VM. Compose remains the **local** story.
+GitHub Actions is the only pipeline: CI on `develop`, a separate Release job onto `main`, then Deploy. Details: [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md) and [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md).
+
+A tagged squash commit on `main` **is** the deploy. Static repos (this wiki, Angular, OpenAPI UI) go to GitHub Pages. `gym-buddy-service` builds a Docker image to GHCR and `replace.sh` replaces the container on the VM. Compose remains the **local** story.
 
 ## Target topology
 
 ```text
-GitHub Pages                         Elsewhere (always-on process)
+GitHub Pages                         OVH VPS (always-on process)
 ─────────────────                    ────────────────────────────
 documentation wiki  ─┐
-Angular member app  ─┼─ static ──►  Spring Boot API ──► PostgreSQL 18
+Angular member app  ─┼─ static ──►  Caddy :443 ──► 127.0.0.1:8080
 Angular back-office ─┤               │
-OpenAPI + Swagger   ─┘               └──► object storage
+OpenAPI + Swagger   ─┘               └── Spring API ──► PostgreSQL 18
+                                     └── object storage (MinIO / S3)
                           ▲
                           └── HTTPS + JWT, CORS allow Pages origins
 ```
 
 ## What to say at the defense
 
-We publish every **static** artifact on GitHub Pages (wiki, Angular, OpenAPI UI). We do **not** pretend Pages runs Java or PostgreSQL; those stay on a small hosted runtime. That is the honest reading of the platform, not a missing feature.
+We publish every **static** artifact on GitHub Pages (wiki, Angular, OpenAPI UI). We do **not** pretend Pages runs Java or PostgreSQL; those stay on a small OVH VPS behind Caddy. That is the honest reading of the platform, not a missing feature.

--- a/20-Architecture/README.md
+++ b/20-Architecture/README.md
@@ -13,7 +13,7 @@ How Gym Buddies is split into systems, where data lives, and why the proposed st
 | [05-Back-office.md](05-Back-office.md) | Admin / moderator console |
 | [06-Data-model.md](06-Data-model.md) | Relational model covering every overview feature |
 | [07-Technology-choices.md](07-Technology-choices.md) | Java 26, Angular 22, TypeScript 7, PostgreSQL 18, OpenAPI repo |
-| [08-Hosting-and-GitHub-Pages.md](08-Hosting-and-GitHub-Pages.md) | What Pages can host (wiki, Angular, OpenAPI UI) and what it cannot (Java, PostgreSQL). Deploy is the tagged Release — see [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md) |
+| [08-Hosting-and-GitHub-Pages.md](08-Hosting-and-GitHub-Pages.md) | Pages for wiki / Angular / OpenAPI UI; OVH VPS + Caddy for Java. Runbook: [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
 Implementation details that are not architectural (JWT shape, signed URLs, fixture generation) live in [40-Technical-specifications](../40-Technical-specifications/README.md).
 

--- a/40-Technical-specifications/01-API-conventions.md
+++ b/40-Technical-specifications/01-API-conventions.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
-| Related | [../20-Architecture/03-Backend.md](../20-Architecture/03-Backend.md), [08-OpenAPI-contract.md](08-OpenAPI-contract.md) |
+| Status | Approved |
+| Related | [../20-Architecture/03-Backend.md](../20-Architecture/03-Backend.md), [08-OpenAPI-contract.md](08-OpenAPI-contract.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
 The human-readable rules on this page must match the machine-readable document in `gym-buddy-openapi`. If they disagree, fix both in the same ticket.
 
@@ -52,4 +52,21 @@ Breaking changes increment `/api/v2`. Additive fields are allowed in v1.
 
 ## Health
 
-`GET /healthz` (liveness) and `GET /readyz` (DB + object store reachable) are unauthenticated.
+Locked public contract (unauthenticated):
+
+| Path | Meaning |
+| --- | --- |
+| `GET /api/v1/healthz` | Liveness — the process is up |
+| `GET /api/v1/readyz` | Readiness — PostgreSQL and object storage are reachable |
+
+Do not publish `/actuator/health` as the contract. Actuator may exist internally.
+
+### Drift until Spring exists
+
+| Surface | Path today | Action |
+| --- | --- | --- |
+| Probe image in `gym-buddy-service` | `GET /` (HTML) | Keep until `pom.xml` exists; then smoke `/api/v1/healthz` |
+| `gym-buddy-openapi` stub | `GET /api/v1/health` | Replace with `healthz` + `readyz` in the same ticket that introduces Spring |
+| This page | `healthz` / `readyz` | Source of truth for the target |
+
+CI smoke scripts change when the service stops being a probe.

--- a/40-Technical-specifications/02-JWT-authentication.md
+++ b/40-Technical-specifications/02-JWT-authentication.md
@@ -2,19 +2,21 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
-| Related | [../30-Functional-specifications/01-Accounts-and-administration.md](../30-Functional-specifications/01-Accounts-and-administration.md) |
+| Status | Approved |
+| Related | [../30-Functional-specifications/01-Accounts-and-administration.md](../30-Functional-specifications/01-Accounts-and-administration.md), [01-API-conventions.md](01-API-conventions.md) |
 
 The brief requires **JWT authentication**. Implementation is ours (no outsourced IdP) so the defense can show claims, expiry, and refresh.
+
+All auth HTTP paths are under `/api/v1`.
 
 ## Tokens
 
 | Token | Where it lives | TTL | Contains |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | Access | `Authorization` header | 15 minutes | `sub`, `role`, `handle`, `typ=access` |
 | Refresh | `HttpOnly; Secure; SameSite=Lax` cookie, path `/api/v1/auth` | 14 days | `sub`, `jti`, `typ=refresh` |
 
-Both are signed with **HS256** at MVP (one secret). RS256 is an improvement if a second service must verify.
+Both are signed with **HS256** at MVP (one secret, `JWT_ACCESS_SECRET`). RS256 is an improvement if a second service must verify.
 
 ## Claims (access)
 
@@ -33,10 +35,10 @@ Do not put email in the access token (leakage via browser logs).
 
 ## Flows
 
-1. `POST /auth/register` → user row + profile + (optional) verification mail
-2. `POST /auth/login` `{ email, password }` → access JSON + `Set-Cookie` refresh
-3. `POST /auth/refresh` (cookie) → new access, rotated refresh (`jti` replaced)
-4. `POST /auth/logout` → refresh `jti` denylisted in Redis until `exp`
+1. `POST /api/v1/auth/register` → user row + profile + (optional) verification mail
+2. `POST /api/v1/auth/login` `{ email, password }` → access JSON + `Set-Cookie` refresh
+3. `POST /api/v1/auth/refresh` (cookie) → new access, rotated refresh (`jti` replaced)
+4. `POST /api/v1/auth/logout` → refresh `jti` denylisted in Redis until `exp`
 5. Locked user: login and refresh fail
 
 ## Password
@@ -45,7 +47,7 @@ Argon2id, memory ≥ 19 MiB, one-way. Timing-safe compare. Generic error on unkn
 
 ## Guards
 
-A Spring Security filter (or `OncePerRequestFilter`) verifies signature, `exp`, `typ=access`, and that `users.status = active`. A method-security expression (`@PreAuthorize("hasRole('ADMIN')")`) or a dedicated voter checks `role` for `/admin/*`.
+A Spring Security filter (or `OncePerRequestFilter`) verifies signature, `exp`, `typ=access`, and that `users.status = active`. A method-security expression (`@PreAuthorize("hasRole('ADMIN')")`) or a dedicated voter checks `role` for `/api/v1/admin/*`.
 
 ## Threat notes
 

--- a/40-Technical-specifications/04-Image-storage.md
+++ b/40-Technical-specifications/04-Image-storage.md
@@ -2,14 +2,16 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
-| Related | [03-Authorization-and-file-access.md](03-Authorization-and-file-access.md) |
+| Status | Approved |
+| Related | [03-Authorization-and-file-access.md](03-Authorization-and-file-access.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
 The brief: **avoid running out of local storage**.
 
 ## Decision
 
 Store bytes in an **S3-compatible bucket** (MinIO in development). The API container’s disk holds only temp files during processing, capped and cleaned.
+
+When `SPRING_PROFILES_ACTIVE=prod`, the API **must refuse to start** if `S3_ENDPOINT` / `S3_BUCKET` / credentials are missing or unreachable. Falling back to a local `uploads/` directory is forbidden.
 
 ## Layout
 

--- a/40-Technical-specifications/07-Test-fixtures.md
+++ b/40-Technical-specifications/07-Test-fixtures.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
-| Related | [../80-Testing/01-Test-plan.md](../80-Testing/01-Test-plan.md) |
+| Status | Approved |
+| Related | [../80-Testing/01-Test-plan.md](../80-Testing/01-Test-plan.md), [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md) |
 
 The brief requires **thousands of test fixtures**.
 
@@ -15,7 +15,7 @@ The brief requires **thousands of test fixtures**.
 
 ## How
 
-Factory functions (`userFactory`, `postFactory`, …) on top of `@faker-js/faker` with a **fixed seed** (`FIXTURE_SEED=20260813`).
+Factory classes (`UserFactory`, `PostFactory`, …) on top of **Datafaker** (Java) with a **fixed seed** (`FIXTURE_SEED=20260813`). This matches the Approved stack. Do not add `@faker-js/faker` to the backend.
 
 A CLI / back-office action:
 
@@ -46,12 +46,12 @@ Do **not** store 15 000 unique JPEGs. Upload ~10 stock images to MinIO and point
 - Clusters by `city` + `sports` (so search and matching are visibly right)
 - Named demo accounts that always exist:
 
-| Handle | Role | Password (dev only) |
+| Handle | Role | Password |
 | --- | --- | --- |
-| `demo.alex` | member | in `.env.example` |
-| `demo.blake` | member, friend of alex | |
-| `demo.mod` | moderator | |
-| `demo.admin` | admin | |
+| `demo.alex` | member | local `.env` only |
+| `demo.blake` | member, friend of alex | local `.env` only |
+| `demo.mod` | moderator | local `.env` only |
+| `demo.admin` | admin | local `.env` only |
 
 ## Safety
 

--- a/40-Technical-specifications/08-OpenAPI-contract.md
+++ b/40-Technical-specifications/08-OpenAPI-contract.md
@@ -5,7 +5,9 @@
 | Status | Approved |
 | Related | [01-API-conventions.md](01-API-conventions.md), [../10-Getting-started/02-Related-repositories.md](../10-Getting-started/02-Related-repositories.md), [../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md) |
 
-The HTTP API is specified in a **dedicated repository** (`gym-buddy-openapi`), not discovered from a running backend.
+The HTTP API is specified in a **dedicated repository**, not discovered from a running backend.
+
+**Repository:** https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi (private, default branch `develop`)
 
 ## Source of truth
 
@@ -16,6 +18,15 @@ The HTTP API is specified in a **dedicated repository** (`gym-buddy-openapi`), n
 | Backend | Implements the tagged spec; contract tests fail the build on drift |
 | Frontend | Generates a TypeScript client from the same tag |
 | Spring `springdoc` `/v3/api-docs` | Optional **dev** convenience only. Never the published contract. |
+
+## Today versus target
+
+| | Today | Target |
+| --- | --- | --- |
+| Document | OpenAPI 3.1.0 stub | Full `/api/v1` |
+| Health | `GET /api/v1/health` | `GET /api/v1/healthz` and `GET /api/v1/readyz` |
+
+Change the stub in the same ticket that introduces Spring. Locked paths: [01-API-conventions.md](01-API-conventions.md).
 
 ## Why not “just expose `/v3/api-docs`”
 

--- a/70-Engineering-practices/07-CI-CD.md
+++ b/70-Engineering-practices/07-CI-CD.md
@@ -3,16 +3,18 @@
 | Field | Value |
 | --- | --- |
 | Status | Approved |
-| Related | [02-Git-workflow.md](02-Git-workflow.md), [06-Versioning.md](06-Versioning.md), [../20-Architecture/08-Hosting-and-GitHub-Pages.md](../20-Architecture/08-Hosting-and-GitHub-Pages.md) |
+| Related | [02-Git-workflow.md](02-Git-workflow.md), [06-Versioning.md](06-Versioning.md), [../20-Architecture/08-Hosting-and-GitHub-Pages.md](../20-Architecture/08-Hosting-and-GitHub-Pages.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
 How Gym Buddies is built, proven, released, and put on a machine. Tooling is **GitHub Actions** (the Jenkins-style job runner that lives next to the code). There is no separate Jenkins server.
+
+The operator runbook (ports, compose plan, VPS, Caddy, UFW) is [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md). This page is the pipeline contract.
 
 ## What we are automating
 
 Three promises, three workflows. They are not the same job.
 
 | Workflow | File | Trigger | Promise |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | **CI** | `.github/workflows/ci.yml` | Every pull request **to `develop`**, and every push **on `develop`** | The change is formatted, tested, and the built artifact actually **runs** |
 | **Release** | `.github/workflows/release.yml` | Manual `workflow_dispatch` (the “Jenkins release” button) | Format → test → smoke → **squash-merge `develop` onto `main`** → **annotated tag `vX.Y.Z`** |
 | **Deploy** | `.github/workflows/deploy.yml` | A `v*` tag on `main`, or called by Release | Distribute that version: GitHub Pages and/or a Docker image on the target VM |
@@ -27,7 +29,7 @@ feature/* ──PR──► develop          CI on every PR and every push
                     main   one squash commit + tag vX.Y.Z
                       │
                       ▼
-                   Deploy  Pages and/or docker pull on the VM
+                   Deploy  Pages and/or GHCR + replace.sh on the VM
 ```
 
 ## CI vs CD (the words)
@@ -73,7 +75,7 @@ Runs on `ubuntu-latest`. It never publishes.
 | --- | --- |
 | Format | The tree matches the formatter. This wiki: Prettier on YAML / JSON / HTML (`prettier --check`). Markdown is **not** auto-reflowed (tables and Mermaid). Application repos: Spotless / Prettier. CI does **not** rewrite files. |
 | Test | Repo-specific tests. In this wiki: every content folder still has a `README.md`, required pipeline files exist. Later: JUnit, Angular unit tests, OpenAPI lint. |
-| Smoke | The **built** thing is started and answers HTTP. Compiling is not enough. This wiki: Jekyll writes `_site/`, a local static server is started, `curl` must get a page that contains “Gym Buddies”. Service: container starts and `/` or `/actuator/health` returns 2xx. |
+| Smoke | The **built** thing is started and answers HTTP. Compiling is not enough. This wiki: Jekyll writes `_site/`, a local static server is started, `curl` must get a page that contains “Gym Buddies”. Service **today** (Python probe): container starts and `GET /` returns 2xx. Service **target** (Spring): `GET /api/v1/healthz` and `GET /api/v1/readyz` return 2xx. Do not treat `/actuator/health` as the public smoke. |
 
 Required check name on `develop`: **`ci`**.
 
@@ -115,13 +117,15 @@ Release then, in order:
 3. Runs the same tests as CI.
 4. Builds the project and **smokes it** (process up, HTTP 2xx).
 5. Computes the version (manual or automatic).
-6. Moves `CHANGELOG.md` bullets from `Unreleased` into `## [X.Y.Z] — <date>`.
+6. Moves `CHANGELOG.md` bullets from `Unreleased` into `## [X.Y.Z] — `.
 7. Commits any prep onto `develop` as `chore(release): prepare vX.Y.Z`.
 8. `git merge --squash` of `develop` onto `main`, commit `release: vX.Y.Z`, annotated tag `vX.Y.Z`, push `main` and the tag.
 9. Merges `main` back into `develop` (`chore(release): sync develop with vX.Y.Z`) so the next squash does not replay history.
 10. Calls **Deploy**.
 
 If any of 2–4 fail, steps 7–10 do not run.
+
+On `gym-buddy-service` this is how **v0.1.1** was cut.
 
 ### Deploy — distribution
 
@@ -130,15 +134,19 @@ Triggered by the `v*` tag (and always invoked by Release, because a push made wi
 | Repository | Artifact | Where it goes |
 | --- | --- | --- |
 | `gym-buddy-documentation` | Jekyll `_site/` | GitHub Pages |
-| `gym-buddy-ui` | `ng build` static files | GitHub Pages |
-| `gym-buddy-openapi` | Spec + Swagger/Redoc | GitHub Pages |
-| `gym-buddy-service` | Docker image | `ghcr.io/<owner>/gym-buddy-service:vX.Y.Z` **and**, if SSH secrets exist, `docker pull` + replace the container on the VM |
+| `gym-buddy-ui` | `ng build` static files | GitHub Pages (when the repo can publish Pages) |
+| `gym-buddy-openapi` | Spec + Swagger/Redoc | GitHub Pages (when the repo can publish Pages) |
+| `gym-buddy-service` | Docker image | `ghcr.io/projet-de-compensation-2025-2026/gym-buddy-service:vX.Y.Z` **and** SSH `replace.sh` on the VPS |
 
-Service deploy on the VM (when secrets are set):
+Service deploy on the VM (secrets are set):
 
 1. Build `docker build` of the tagged commit.
 2. Push to GHCR.
-3. SSH to `DEPLOY_HOST` and run the replace script (pull the new tag, `docker compose up -d`, drop the previous container).
+3. SSH to `DEPLOY_HOST` as `DEPLOY_USER`.
+4. `replace.sh` runs `docker login ghcr.io` with `GITHUB_TOKEN` and `github.actor` (private image).
+5. Pull the new tag, stop the previous container, `docker run` the new one bound to `${DEPLOY_BIND:-127.0.0.1}:${PORT:-8080}:8080`.
+
+This is **not** `docker compose up -d` on the VM. Compose is the **local** (and later private data-plane) story. The public HTTP entry is Caddy on the hostname, proxying to loopback `:8080`.
 
 ## Repository rules (so `main` stays clean)
 
@@ -184,8 +192,8 @@ Each repository owns four scripts. Workflows call them; they do not inline stack
 | `.github/scripts/ci/next_version.py` | no | yes |
 | `.github/scripts/ci/prepare_changelog.py` | no | yes |
 
-When application code appears, **change the scripts**, not the workflow names or triggers. The contract on this page stays.
+When application code appears, **change the scripts**, not the workflow names or triggers. The contract on this page stays. Service smoke moves from `GET /` to `/api/v1/healthz` + `/readyz` when `pom.xml` exists.
 
 ## What to say at the defense
 
-We use GitHub Actions as the only CI/CD runner. Pull requests onto `develop` always run format, tests, and a live smoke. A separate Release workflow is the only way onto `main`: it squash-merges, tags SemVer (automatic or typed in), and that tag is the deploy.
+We use GitHub Actions as the only CI/CD runner. Pull requests onto `develop` always run format, tests, and a live smoke. A separate Release workflow is the only way onto `main`: it squash-merges, tags SemVer (automatic or typed in), and that tag is the deploy. The API image is pulled on an OVH VPS, bound to localhost, and served by Caddy.

--- a/70-Engineering-practices/README.md
+++ b/70-Engineering-practices/README.md
@@ -12,8 +12,10 @@ How we write, review, and ship code and documentation across Gym Buddies reposit
 | [04-Documentation-conventions.md](04-Documentation-conventions.md) | Numbering, page template, linking, changelog entries |
 | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md) | Issues live here, must link a wiki page, commit scope = ticket id |
 | [06-Versioning.md](06-Versioning.md) | [Semantic Versioning 2.0.0](https://semver.org/) — `0.y.z` until the academic `1.0.0` |
-| [07-CI-CD.md](07-CI-CD.md) | GitHub Actions: CI on `develop`, Release squash+tag onto `main`, Deploy |
+| [07-CI-CD.md](07-CI-CD.md) | GitHub Actions: CI on `develop`, Release squash+tag onto `main`, Deploy (Pages or `replace.sh`) |
 | [08-Feature-implementation.md](08-Feature-implementation.md) | Consult Joaquim → update specs → ticket on **Gym Buddy Project** → `Not Ready` / `Todo` / `In Progress` / `Done` |
+
+Operator runbook (local compose, env keys, VPS): [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md).
 
 These practices exist so the software-engineering module is visible in the daily workflow, not only in UML.
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -11,7 +11,18 @@ Until the first application release, versions refer to the **documentation contr
 
 ### Added
 
+- Environment and pipeline runbook: local compose plan (PostgreSQL 18, Redis, MinIO, API, optional MailHog), env key catalog, CI/Release/Deploy as built, OVH VPS + Caddy + UFW
+- How to record the instructor cadrage (no invented minutes)
+- Academic report chapter map, presentation speaker notes, screenshot checklist including VPS health
+
 ### Changed
+
+- Related-repository table now uses the four real GitHub URLs
+- CI/CD: VM replace is `replace.sh` + `docker run` on `127.0.0.1`, not `docker compose up -d`; GHCR login on the VM; probe smoke is `GET /`, target is `/api/v1/healthz` and `/readyz`
+- Hosting: backend is the OVH VPS `vps-c39cdf03.vps.ovh.net`, not a generic PaaS
+- Fixtures: Datafaker (Java), not `@faker-js/faker`
+- Technology-choices cadence row: Approved
+- Changelog compare links point at this repository
 
 ## [0.2.0] — 2026-08-14
 
@@ -42,6 +53,6 @@ Until the first application release, versions refer to the **documentation contr
 
 - English and French assignment text under `00-Project-brief`
 
-[Unreleased]: https://github.com/
+[Unreleased]: https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/releases/tag/v0.2.0
-[0.1.0]: https://github.com/
+[0.1.0]: https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/releases/tag/v0.1.0

--- a/91-Critical-analysis/01-Current-analysis.md
+++ b/91-Critical-analysis/01-Current-analysis.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Draft |
-| Related | [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md) |
+| Related | [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
 This page is updated after implementation. It already records **design-level** strengths and weaknesses so the report is not written the night before the defense.
 
@@ -15,18 +15,20 @@ This page is updated after implementation. It already records **design-level** s
 - Object storage + signed URLs answers the brief’s storage and security items directly.
 - Spec IDs give tests and the report a traceability story.
 - Two clients (member + back-office) satisfy the implementation triad without a mobile program.
+- The live API already has a pipeline (CI → Release → GHCR → `replace.sh`) and a named host (`vps-c39cdf03.vps.ovh.net`) behind Caddy.
 
 ## Weaknesses
 
 - Java 26 is the latest GA but not the LTS (that is 25). A library may force a temporary pin to 25.
 - TypeScript 7.0 is new (Go native compiler, July 2026). Angular 22 may trail it by a patch; that gap is a tooling risk, not a product one.
-- GitHub Pages cannot host the Java API or PostgreSQL; the defense must show a second host.
+- GitHub Pages cannot host the Java API or PostgreSQL. The API runs on the OVH VPS; 443 is limited to the operator network, so a stranger cannot open the demo URL without that prefix on UFW.
 - JWT HS256 + Redis denylist is not an identity platform (no step-up auth, no device list).
 - Nested comments capped at depth 4 and stored `depth` will need a migration if the cap changes.
 - Greedy matching is a 1/2-approximation; we do not yet show empirical gap vs exact.
 - Search quality on messy city strings will be poor without geocoding.
 - Instant messaging is not E2E encrypted; staff can read plaintext in the DB.
 - Large fixtures with shared image keys make the demo look repetitive.
+- The service is still a Python probe. Spring, compose, and Angular are not started.
 
 ## Risks
 
@@ -37,7 +39,8 @@ This page is updated after implementation. It already records **design-level** s
 | Race on event capacity | Oversell seats | Transaction + `SELECT FOR UPDATE` |
 | Private data leaks in search | Failed security story | Integration tests listed in the plan |
 | Single student bus factor | No backup | Wiki is the backup: another engineer could implement from it |
+| Certificate renewal while 443 is firewalled | HTTPS expires | Open port 80 briefly for HTTP-01, then deny it again |
 
 ## Academic honesty
 
-Do not claim machine learning if we ship weighted sums. The justification pages exist so the defense can be precise.
+Do not claim machine learning if we ship weighted sums. The justification pages exist so the defense can be precise. Do not claim Spring is in production while the probe image is what Deploy ships.

--- a/99-Academic-deliverables/01-Report-outline.md
+++ b/99-Academic-deliverables/01-Report-outline.md
@@ -2,16 +2,18 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Draft |
-| Related | [../00-Project-brief/ProjetDeCompensation2526.en.md](../00-Project-brief/ProjetDeCompensation2526.en.md) |
+| Status | Draft — template complete; PDF not assembled |
+| Related | [../00-Project-brief/ProjetDeCompensation2526.en.md](../00-Project-brief/ProjetDeCompensation2526.en.md), [03-Screenshots.md](03-Screenshots.md) |
 
 The report **summarizes** this wiki and the implementation. It is not a second specification. Assemble it in the last weeks; keep screenshots current.
+
+**Blocked on:** Spring + Angular implementation, screenshot set, instructor cadrage notes. Do not export a PDF that pretends those exist.
 
 ## Required contents (brief)
 
 | Required | Source in this wiki |
 | --- | --- |
-| Link to the private GitHub repository | [../10-Getting-started/02-Related-repositories.md](../10-Getting-started/02-Related-repositories.md) — list every repo and confirm instructor access |
+| Link to the private GitHub repositories | [../10-Getting-started/02-Related-repositories.md](../10-Getting-started/02-Related-repositories.md) — all four URLs, instructor collaborator |
 | Screenshots of major features | [03-Screenshots.md](03-Screenshots.md) |
 | Software architecture | [../20-Architecture/01-Software-architecture.md](../20-Architecture/01-Software-architecture.md) |
 | Data model | [../20-Architecture/06-Data-model.md](../20-Architecture/06-Data-model.md) |
@@ -24,23 +26,34 @@ Also include, because the task list asks for them:
 
 - Test plan and unit-test summary — [../80-Testing](../80-Testing/README.md)
 - Critical analysis — [../91-Critical-analysis](../91-Critical-analysis/README.md)
+- How it is hosted and shipped — [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md)
 
-## Suggested chapter map
+## Repository URLs to cite
 
-1. Introduction and academic framing (5 ECTS, modules, individual)
-2. Problem and users
-3. Functional overview (table of FS areas)
-4. Architecture and data model
-5. Algorithms (one chapter, three sections)
-6. Security (JWT + file access)
-7. Implementation notes (backend, frontend, back-office)
-8. Tests and fixtures
-9. Critical analysis and improvements
-10. Conclusion
-11. Appendix: full UML, selected OpenAPI, instructor-scoping notes
+- https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation
+- https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service
+- https://github.com/Projet-de-compensation-2025-2026/gym-buddy-ui
+- https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi
+
+## Chapter map (write from the wiki, do not redesign)
+
+| # | Chapter | Pull from | Notes when writing |
+| --- | --- | --- | --- |
+| 1 | Introduction and academic framing | `00-Project-brief` | 5 ECTS, three modules, individual work, deadline 31 August 2026 |
+| 2 | Problem and users | brief + `02-System-context` | Athletes who want a training partner |
+| 3 | Functional overview | `30-Functional-specifications` | One table of FS areas, then 1–2 pages of highlights (feed, events, suggestions) |
+| 4 | Architecture and data model | `20-Architecture/01`, `06` | Modular monolith, four repos, ER of 6–8 core entities |
+| 5 | Algorithms | `50-Algorithms` | Suggestions, filtered search, matching — formula + complexity + why not ML |
+| 6 | Security | `40-Technical-specifications/02` + `03` | JWT HS256, Argon2id, `canRead`, signed URLs |
+| 7 | Implementation notes | service / UI READMEs + environment runbook | Backend, frontend, back-office, VPS + Caddy. Be honest about probe vs Spring if still mid-build |
+| 8 | Tests and fixtures | `80-Testing` + `07-Test-fixtures` | Pyramid, Datafaker, seed `20260813`, 3 000 users |
+| 9 | Critical analysis and improvements | `91-Critical-analysis` | Pre-impl critique plus what you would change after coding |
+| 10 | Conclusion | — | What the three modules demonstrated |
+| 11 | Appendix | UML, selected OpenAPI, cadrage notes | Cite the documentation commit hash |
 
 ## Formalities
 
 - Due 31 August 2026 by email to [maurras.togbe@isep.fr](mailto:maurras.togbe@isep.fr)
 - Language: confirm with the instructor (assignment is French; this wiki is English). If the report must be French, translate from this outline, do not rewrite the design.
 - Cite the documentation repo commit hash used for the PDF export.
+- File name when it exists: `Gym-Buddies-report.pdf` in this folder or a release asset. Do not commit a hollow PDF.

--- a/99-Academic-deliverables/02-Presentation.md
+++ b/99-Academic-deliverables/02-Presentation.md
@@ -2,27 +2,29 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Draft |
+| Status | Draft — slide spine complete; `.pptx` not built |
 | Related | [../00-Project-brief/02-Stakeholders-and-defense.md](../00-Project-brief/02-Stakeholders-and-defense.md) |
 
 Defense: **20 minutes** + **30 minutes Q&A**, in person or remote.
 
+**Blocked on:** a demoable UI (or a recorded fallback). Do not commit an empty `Gym-Buddies-defense.pptx`.
+
 ## Slide spine (≈ 12 slides)
 
-| # | Slide | Minutes | Talk about |
-| --- | --- | --- | --- |
-| 1 | Title | 0.5 | Gym Buddies, ISEP 2025/2026, your name |
-| 2 | Problem | 1 | Athletes train alone; need a buddy |
-| 3 | Scope | 1 | Modules, in-scope list, explicit out-of-scope |
-| 4 | Demo 1 — social | 4 | Feed, post, nested comment, like, friend accept |
-| 5 | Demo 2 — session | 4 | Friends-only event, apply, accept, capacity |
-| 6 | Demo 3 — buddy | 2 | Suggestions + DM image |
-| 7 | Architecture | 2 | Modular monolith, three apps, MinIO, Postgres |
-| 8 | Data model | 1 | 6–8 entities, not the whole ER |
-| 9 | Algorithm deep dive | 3 | Suggestions **or** matching — formula + why not ML |
-| 10 | Security | 1.5 | JWT + `canRead` + signed URL |
-| 11 | Tests and fixtures | 1 | Pyramid + 3 000 users |
-| 12 | Limits and Q&A | 0.5 | Honest gaps |
+| # | Slide | Minutes | Talk about | Speaker notes |
+| --- | --- | --- | --- | --- |
+| 1 | Title | 0.5 | Gym Buddies, ISEP 2025/2026, Joaquim Kéloglanian | One line: social app to find a gym buddy. |
+| 2 | Problem | 1 | Athletes train alone; need a buddy | Keep it human. No stack yet. |
+| 3 | Scope | 1 | Modules, in-scope list, explicit out-of-scope | Point at `01-Scope-and-modules.md`. Mention cadrage if it happened. |
+| 4 | Demo 1 — social | 4 | Feed, post, nested comment, like, friend accept | Live as `demo.alex`. If it fails, play the offline recording. |
+| 5 | Demo 2 — session | 4 | Friends-only event, apply, accept, capacity | Show a full event and a rejected extra applicant. |
+| 6 | Demo 3 — buddy | 2 | Suggestions + DM image | Read the “why” line on a suggestion. |
+| 7 | Architecture | 2 | Modular monolith, four repos, MinIO, Postgres, VPS | Wiki + OpenAPI + service + UI. Pages for static; OVH for Java. |
+| 8 | Data model | 1 | 6–8 entities, not the whole ER | User, Friendship, Post, Comment, Event, Media. |
+| 9 | Algorithm deep dive | 3 | Suggestions **or** matching — formula + why not ML | One formula on the slide. Complexity on 3k users. |
+| 10 | Security | 1.5 | JWT + `canRead` + signed URL | Stranger cannot fetch an object key. |
+| 11 | Tests and fixtures | 1 | Pyramid + 3 000 users | Datafaker, seed `20260813`. |
+| 12 | Limits and Q&A | 0.5 | Honest gaps | What you would drop with two weeks less. |
 
 If demo environments fail, slides 4–6 become the recorded video. Keep that file **offline**.
 
@@ -35,6 +37,7 @@ If demo environments fail, slides 4–6 become the recorded video. Keep that fil
 - How is a recurring event stored?
 - Show a unit test for matching.
 - What would you drop if you had two weeks less?
+- How does a commit reach the VPS? (CI → Release button → GHCR → `replace.sh` → Caddy)
 
 Answers should point at a spec ID, not a new story.
 

--- a/99-Academic-deliverables/03-Screenshots.md
+++ b/99-Academic-deliverables/03-Screenshots.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Draft |
+| Status | Draft — checklist complete; images blocked on UI |
 
-Capture after the UI is stable. Prefer the `demo.alex` / `demo.blake` accounts. Store images next to this file (`screenshots/`) when they exist.
+Capture after the UI is stable. Prefer the `demo.alex` / `demo.blake` accounts. Store images next to this file (`screenshots/`) when they exist. Do not commit placeholder images.
 
 | # | Shot | Feature | FS |
 | --- | --- | --- | --- |
@@ -26,5 +26,8 @@ Capture after the UI is stable. Prefer the `demo.alex` / `demo.blake` accounts. 
 | 16 | Back-office: hidden post | Moderation | FS-ADM-03 |
 | 17 | Architecture diagram (export from wiki Mermaid) | Deliverable | — |
 | 18 | Data model diagram | Deliverable | — |
+| 19 | HTTPS probe / health on the VPS (operator network) | Hosting | — |
 
-Each figure in the report gets a one-sentence caption. Do not paste 18 shots without commentary.
+Each figure in the report gets a one-sentence caption. Do not paste 19 shots without commentary.
+
+Shots 1–16 wait for Angular. Shots 17–18 can be exported from this wiki now. Shot 19 can be taken from `https://vps-c39cdf03.vps.ovh.net` on the operator network.

--- a/99-Academic-deliverables/README.md
+++ b/99-Academic-deliverables/README.md
@@ -2,13 +2,15 @@
 
 Packaging of the work for ISEP. Content is assembled **from** the rest of this wiki; do not invent a second architecture or a second spec set here.
 
+The PDF, PowerPoint, and screenshot gallery are **not assembled yet**. They are blocked on a working UI and on the instructor cadrage. The pages below are the complete writing plan so those files can be produced in the last weeks without redesigning the product.
+
 ## Contents
 
-| Document | Brief deliverable |
-| --- | --- |
-| [01-Report-outline.md](01-Report-outline.md) | Report: GitHub link, screenshots, architecture, data model, UML, justifications, specs |
-| [02-Presentation.md](02-Presentation.md) | PowerPoint structure for the 20 min + 30 min Q&A defense |
-| [03-Screenshots.md](03-Screenshots.md) | Checklist of major features to capture |
+| Document | Brief deliverable | Status |
+| --- | --- | --- |
+| [01-Report-outline.md](01-Report-outline.md) | Report: GitHub links, screenshots, architecture, data model, UML, justifications, specs | Template complete — PDF not written |
+| [02-Presentation.md](02-Presentation.md) | PowerPoint structure for the 20 min + 30 min Q&A defense | Slide spine + speaker notes — `.pptx` not built |
+| [03-Screenshots.md](03-Screenshots.md) | Checklist of major features to capture | Checklist complete — images blocked on UI |
 
 Submission reminder: email [maurras.togbe@isep.fr](mailto:maurras.togbe@isep.fr) no later than **31 August 2026**, and add that account to GitHub.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Top-level folders follow `XX-Section-name`, where `XX` is `00`–`99`. Numbers a
 | Folder | What you will find |
 | --- | --- |
 | [00-Project-brief](00-Project-brief/README.md) | Official assignment (FR/EN), academic scope, stakeholders, defense constraints |
-| [10-Getting-started](10-Getting-started/README.md) | How to read this wiki, related repositories, glossary |
-| [20-Architecture](20-Architecture/README.md) | Software architecture, Java backend / Angular frontend, data model, stack, GitHub Pages |
+| [10-Getting-started](10-Getting-started/README.md) | How to read this wiki, related repositories, glossary, **environment and pipeline runbook** |
+| [20-Architecture](20-Architecture/README.md) | Software architecture, Java backend / Angular frontend, data model, stack, GitHub Pages + OVH VPS |
 | [30-Functional-specifications](30-Functional-specifications/README.md) | Product behavior for every feature listed in the assignment overview |
 | [40-Technical-specifications](40-Technical-specifications/README.md) | JWT, file access, image storage, messaging transport, search, fixtures, API conventions |
 | [50-Algorithms](50-Algorithms/README.md) | Friend suggestions, filtered search, user matching — with justification |
@@ -38,8 +38,9 @@ Every folder has its own `README.md`. Start there when you land in a section.
 
 1. Read the English assignment: [00-Project-brief/ProjetDeCompensation2526.en.md](00-Project-brief/ProjetDeCompensation2526.en.md)
 2. Skim [10-Getting-started/01-How-to-use-this-wiki.md](10-Getting-started/01-How-to-use-this-wiki.md)
-3. Open [20-Architecture/01-Software-architecture.md](20-Architecture/01-Software-architecture.md) for the system map
-4. Jump to a feature in [30-Functional-specifications](30-Functional-specifications/README.md)
+3. Read [10-Getting-started/04-Environment-and-pipeline.md](10-Getting-started/04-Environment-and-pipeline.md) for local compose, env keys, CI/CD, and the VPS
+4. Open [20-Architecture/01-Software-architecture.md](20-Architecture/01-Software-architecture.md) for the system map
+5. Jump to a feature in [30-Functional-specifications](30-Functional-specifications/README.md)
 
 ## Assignment coverage
 
@@ -58,6 +59,7 @@ Everything required by the compensation brief is recorded in this repository:
 | Justification of libraries, languages, frameworks | [20-Architecture/07-Technology-choices.md](20-Architecture/07-Technology-choices.md) |
 | Report, screenshots, architecture, data model, UML, PowerPoint | [99-Academic-deliverables](99-Academic-deliverables/README.md) |
 | Code practices and workflows | [70-Engineering-practices](70-Engineering-practices/README.md) |
+| Local environment, pipeline, VPS | [10-Getting-started/04-Environment-and-pipeline.md](10-Getting-started/04-Environment-and-pipeline.md) |
 | Version changelogs | [90-Changelog](90-Changelog/README.md) |
 
 ## Document status
@@ -71,7 +73,7 @@ Pages use a short status table:
 | `Approved` | Locked for implementation |
 | `Deprecated` | Kept for history only |
 
-Until the instructor meeting in [00-Project-brief/01-Scope-and-modules.md](00-Project-brief/01-Scope-and-modules.md) is recorded, treat product pages as **Draft** and technical choices as **Proposed**.
+Until the instructor meeting in [00-Project-brief/01-Scope-and-modules.md](00-Project-brief/01-Scope-and-modules.md) is recorded, treat **product** pages as **Draft**. Stack, hosting, CI/CD, and the environment runbook are **Approved** for implementation unless that meeting overturns them.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Finishes the wiki as a documentation set for the project as it exists today, including the environment and pipeline runbook.

- New [environment and pipeline runbook](10-Getting-started/04-Environment-and-pipeline.md): local compose plan, env keys, CI/Release/Deploy as built, OVH VPS + Caddy + UFW
- Real GitHub URLs for all four repos
- CI/CD and hosting aligned with `replace.sh` (localhost bind, GHCR login), not `docker compose up -d` on the VM
- Health locked to `/api/v1/healthz` and `/readyz` (probe still `GET /` until Spring)
- Fixtures use Datafaker, not faker-js
- Academic report / presentation / screenshots finished as templates (no fake PDF, pptx, or UI shots)
- Instructor cadrage still Not done; how to record it is written

No secrets, SSH keys, or operator IP prefix in this public repo.

Report/pptx/screenshots are complete writing plans, not assembled deliverables. Those wait on a working UI.

## Test plan

- [ ] Read the new runbook as a newcomer
- [ ] Confirm private repo URLs and instructor collaborator note
- [ ] Confirm CI-CD no longer says VM compose up
- [ ] Confirm no home IPv6 prefix in the diff