### PR TITLE
Auto-add every ticket to Gym Buddy Project

### DIFF
--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -1,16 +1,20 @@
 name: Ticket
-description: Work item. Must link a page in this documentation repository.
+description: Work item. Must link a wiki page. Automatically added to Gym Buddy Project.
 title: "[GB] "
 labels: []
+projects: ["Projet-de-compensation-2025-2026/1"]
 body:
   - type: markdown
     attributes:
       value: |
         Tickets live in **gym-buddy-documentation**. Every ticket must point at a wiki page
-        (functional spec, technical spec, algorithm, architecture, test plan, …)
-        and must be attached to the singular **Gym Buddy Project**.
-        Fill every field. New tickets default to **Not Ready**; only Joaquim Kéloglanian
-        moves them to **Todo** after an explicit review.
+        (functional spec, technical spec, algorithm, architecture, test plan, …).
+
+        **This form adds the issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1).**
+        That is the only board. Do not create a second project. Do not leave the issue
+        sitting only in the repo issues list. Status starts at **Not Ready**;
+        only Joaquim Kéloglanian moves it to **Todo** after an explicit review.
+
         See `70-Engineering-practices/08-Feature-implementation.md`
         and `70-Engineering-practices/05-Tickets-and-GitHub-projects.md`.
   - type: dropdown
@@ -58,3 +62,11 @@ body:
       description: Checklist copied or cited from the linked spec
     validations:
       required: true
+  - type: checkboxes
+    id: on-project
+    attributes:
+      label: Gym Buddy Project
+      description: Required. The form already attaches this issue to the project. Confirm you will not remove it.
+      options:
+        - label: This ticket belongs on [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1) (Status starts at Not Ready). I will not remove it from the board.
+          required: true

--- a/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
+++ b/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
@@ -19,7 +19,16 @@ Reasons:
 - One sequence of ids (`#1`, `#2`, …) is shared across all implementation repos
 - Commits in other repos can still link here with `Refs: <owner>/gym-buddy-documentation#42`
 
-**Gym Buddy Project** is the only board. Every ticket opened from the template is attached to it. New items default to `Not Ready`. The four statuses and who may change them are defined in [08-Feature-implementation.md](08-Feature-implementation.md).
+**Gym Buddy Project** is the only board. Every ticket is attached to it **at creation**. There is no “open the issue, add it to the board later” step.
+
+How that is enforced:
+
+1. The issue form [`.github/ISSUE_TEMPLATE/ticket.yml`](../../.github/ISSUE_TEMPLATE/ticket.yml) sets `projects: ["Projet-de-compensation-2025-2026/1"]`. GitHub adds the issue to the project when the form is submitted. The opener needs write access on the project (org members do).
+2. The same form has a required checkbox: the ticket belongs on Gym Buddy Project and must not be removed.
+3. Blank issues are disabled (`config.yml`). Use the Ticket form.
+4. If an issue is created **outside** the form (API, `gh issue create`), attach it to the project in the same action. Status starts at `Not Ready`.
+
+New items default to `Not Ready`. The four statuses and who may change them are defined in [08-Feature-implementation.md](08-Feature-implementation.md).
 
 ## Mandatory ticket contents
 
@@ -33,8 +42,9 @@ A ticket is not ready for implementation unless it has **all** of the following:
 | Spec IDs | `FS-…` / `TS-…` when the page defines them |
 | Target repo | `gym-buddy-documentation`, `gym-buddy-service`, `gym-buddy-ui`, and/or `gym-buddy-openapi` |
 | Acceptance | Checklist copied or cited from the spec |
+| **Gym Buddy Project** | Attached at creation. Status visible on the board. |
 
-The issue template under [`.github/ISSUE_TEMPLATE/ticket.yml`](../../.github/ISSUE_TEMPLATE/ticket.yml) makes the wiki link **required**.
+The issue template under [`.github/ISSUE_TEMPLATE/ticket.yml`](../../.github/ISSUE_TEMPLATE/ticket.yml) makes the wiki link **required** and attaches the issue to the project.
 
 Valid wiki links (examples):
 
@@ -43,6 +53,8 @@ Valid wiki links (examples):
 - Several pages if the ticket genuinely spans them
 
 A ticket that only says “implement events” with no wiki link is incomplete. Create or update the spec first, then open the ticket.
+
+A ticket that exists only in the repo issues list, and not on [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1), is incomplete. Attach it before anyone treats it as `Not Ready`.
 
 ## Tickets must reference this repository
 

--- a/70-Engineering-practices/08-Feature-implementation.md
+++ b/70-Engineering-practices/08-Feature-implementation.md
@@ -57,6 +57,10 @@ A ticket that points at a missing or stale spec is invalid. Change the spec in t
 
 Open a GitHub Issue on **`gym-buddy-documentation`** using the existing template [`.github/ISSUE_TEMPLATE/ticket.yml`](../../.github/ISSUE_TEMPLATE/ticket.yml). Fill **every** field. An empty optional-looking box is not optional here.
 
+The form **automatically adds the issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1)** (`projects: Projet-de-compensation-2025-2026/1`). That is required, not optional. Confirm the checkbox. Do not remove the issue from the board afterwards.
+
+If you create an issue without the form, attach it to the project in the same step. An issue that exists only in the repo issues list is not a ticket yet.
+
 | Template field | What to put |
 | --- | --- |
 | Title | `[GB] ` plus one imperative outcome |
@@ -65,10 +69,11 @@ Open a GitHub Issue on **`gym-buddy-documentation`** using the existing template
 | Spec IDs | `FS-…` / `TS-…` from those pages |
 | Implementation repository | Every repo that will change (`gym-buddy-documentation`, `gym-buddy-service`, `gym-buddy-ui`, `gym-buddy-openapi`) |
 | Acceptance | Checklist copied or cited from the linked spec |
+| Gym Buddy Project | Required checkbox. The form already attaches the issue. |
 
 The ticket **must** point at the documentation it implements. A title such as “implement events” with no wiki path is incomplete — go back to step 3.
 
-The ticket **must** be attached to the existing, singular GitHub Project [**Gym Buddy Project**](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1). Do not create a second project. Do not leave the issue sitting only in the repo issues list.
+The ticket **must** be on **Gym Buddy Project**. Do not create a second project.
 
 Newly created tickets default to **`Not Ready`**.
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -14,6 +14,7 @@ Until the first application release, versions refer to the **documentation contr
 - Environment and pipeline runbook: local compose plan (PostgreSQL 18, Redis, MinIO, API, optional MailHog), env key catalog, CI/Release/Deploy as built, OVH VPS + Caddy + UFW
 - How to record the instructor cadrage (no invented minutes)
 - Academic report chapter map, presentation speaker notes, screenshot checklist including VPS health
+- Ticket form auto-adds every new issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1) (`projects: Projet-de-compensation-2025-2026/1`) and requires a confirmation checkbox
 
 ### Changed
 
@@ -23,6 +24,7 @@ Until the first application release, versions refer to the **documentation contr
 - Fixtures: Datafaker (Java), not `@faker-js/faker`
 - Technology-choices cadence row: Approved
 - Changelog compare links point at this repository
+- Tickets: attaching to Gym Buddy Project is required at creation, not later
 
 ## [0.2.0] — 2026-08-14
 


### PR DESCRIPTION
## Summary

Every ticket created from the form lands on [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1).

- `.github/ISSUE_TEMPLATE/ticket.yml` now has `projects: ["Projet-de-compensation-2025-2026/1"]`
- Required checkbox so the opener cannot submit without acknowledging the board
- `05-Tickets-and-GitHub-projects.md` and `08-Feature-implementation.md` say attach at creation, not later

Existing issues #1 and #7 are being attached on the live board (the template only applies to new form submissions).

## Test plan

- [ ] Open **New issue → Ticket** and confirm Gym Buddy Project is listed / the checkbox is required
- [ ] Submit a throwaway ticket (or inspect the form YAML) and see it on the project at Not Ready
- [ ] Blank issues stay disabled
