### PR TITLE
Require engineering practices on tickets; define application 0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -1,5 +1,5 @@
 name: Ticket
-description: Work item. Must link a wiki page. Automatically added to Gym Buddy Project.
+description: Work item. Must link a feature spec and 70-Engineering-practices. Lands on Gym Buddy Project.
 title: "[GB] "
 labels: []
 projects: ["Projet-de-compensation-2025-2026/1"]
@@ -7,16 +7,18 @@ body:
   - type: markdown
     attributes:
       value: |
-        Tickets live in **gym-buddy-documentation**. Every ticket must point at a wiki page
-        (functional spec, technical spec, algorithm, architecture, test plan, …).
+        Tickets live in **gym-buddy-documentation**.
+
+        Every ticket must point at:
+        1. The **feature** wiki page it implements (functional / technical spec, algorithm, architecture, …)
+        2. **`70-Engineering-practices`** — org-wide conventions for code style, Gitflow / Conventional Commits,
+           pull requests, tickets, versioning, and CI/CD. This directory is the source of truth for every
+           repository and every agent. Do not invent a second workflow.
 
         **This form adds the issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1).**
-        That is the only board. Do not create a second project. Do not leave the issue
-        sitting only in the repo issues list. Status starts at **Not Ready**;
-        only Joaquim Kéloglanian moves it to **Todo** after an explicit review.
+        Status starts at **Not Ready**; only Joaquim Kéloglanian moves it to **Todo** after an explicit review.
 
-        See `70-Engineering-practices/08-Feature-implementation.md`
-        and `70-Engineering-practices/05-Tickets-and-GitHub-projects.md`.
+        Start here: [`70-Engineering-practices`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/tree/develop/70-Engineering-practices).
   - type: dropdown
     id: type
     attributes:
@@ -32,8 +34,16 @@ body:
     id: wiki
     attributes:
       label: Documentation page
-      description: Required. Relative path in this repo, for example 30-Functional-specifications/07-Events.md
-      placeholder: 30-Functional-specifications/07-Events.md
+      description: Required. Feature spec path(s) in this repo. Example 30-Functional-specifications/01-Accounts-and-administration.md
+      placeholder: 30-Functional-specifications/01-Accounts-and-administration.md
+    validations:
+      required: true
+  - type: input
+    id: practices
+    attributes:
+      label: Engineering practices
+      description: Required on every ticket. Always this directory. Code style, git, PRs, and workflows for all repos and agents.
+      placeholder: 70-Engineering-practices
     validations:
       required: true
   - type: input
@@ -41,7 +51,7 @@ body:
     attributes:
       label: Spec IDs
       description: FS-EVT-07, TS-JWT-02, … when the page defines them
-      placeholder: FS-EVT-07
+      placeholder: FS-ACCT-01
   - type: dropdown
     id: target-repo
     attributes:
@@ -69,4 +79,12 @@ body:
       description: Required. The form already attaches this issue to the project. Confirm you will not remove it.
       options:
         - label: This ticket belongs on [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1) (Status starts at Not Ready). I will not remove it from the board.
+          required: true
+  - type: checkboxes
+    id: follow-practices
+    attributes:
+      label: Follow engineering practices
+      description: Required. Keeps code style, commits, PRs, and pipelines the same across repositories and agents.
+      options:
+        - label: I will follow [70-Engineering-practices](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/tree/develop/70-Engineering-practices) (coding standards, Gitflow / Conventional Commits, review, tickets, versioning, CI/CD). I will not invent a parallel workflow.
           required: true

--- a/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
+++ b/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
@@ -38,21 +38,24 @@ A ticket is not ready for implementation unless it has **all** of the following:
 | --- | --- |
 | Title | Imperative, scoped to one outcome |
 | Type | Feature, Bug, Chore, or Docs (label) |
-| **Wiki link** | Path or URL of at least one page in **this** repository (functional spec, technical spec, algorithm, architecture, test plan, …) |
+| **Wiki link** | Path of the **feature** page in this repository (functional spec, technical spec, algorithm, architecture, test plan, …) |
+| **Engineering practices** | Always [`70-Engineering-practices`](README.md). Org-wide code style, Gitflow / Conventional Commits, PR review, tickets, versioning, CI/CD. Required so every repository and every agent uses the same workflow. |
 | Spec IDs | `FS-…` / `TS-…` when the page defines them |
 | Target repo | `gym-buddy-documentation`, `gym-buddy-service`, `gym-buddy-ui`, and/or `gym-buddy-openapi` |
 | Acceptance | Checklist copied or cited from the spec |
 | **Gym Buddy Project** | Attached at creation. Status visible on the board. |
 
-The issue template under [`.github/ISSUE_TEMPLATE/ticket.yml`](../../.github/ISSUE_TEMPLATE/ticket.yml) makes the wiki link **required** and attaches the issue to the project.
+The issue template under [`.github/ISSUE_TEMPLATE/ticket.yml`](../../.github/ISSUE_TEMPLATE/ticket.yml) makes the feature wiki link **and** `70-Engineering-practices` required, attaches the issue to the project, and requires a checkbox that the opener will follow this directory.
 
-Valid wiki links (examples):
+Valid feature wiki links (examples):
 
 - `30-Functional-specifications/07-Events.md`
 - `https://<owner>.github.io/gym-buddy-documentation/30-Functional-specifications/07-Events.html` (once Pages is on)
 - Several pages if the ticket genuinely spans them
 
 A ticket that only says “implement events” with no wiki link is incomplete. Create or update the spec first, then open the ticket.
+
+A ticket that does not cite `70-Engineering-practices` is incomplete. That directory is not optional documentation; it is the process the implementation must follow.
 
 A ticket that exists only in the repo issues list, and not on [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1), is incomplete. Attach it before anyone treats it as `Not Ready`.
 

--- a/70-Engineering-practices/06-Versioning.md
+++ b/70-Engineering-practices/06-Versioning.md
@@ -25,6 +25,29 @@ Start at `0.1.0`. During `0.y.z`, increment **y** when we add a feature slice wo
 
 Gitflow: only commits on `main` are tagged, and only by the Release workflow ([07-CI-CD.md](07-CI-CD.md)). `develop` is unreleased (`Unreleased` in the changelog).
 
+## Planned slices (0.y.z)
+
+Documentation and application artifacts may sit on different `0.y.z` numbers until `1.0.0`. This wiki already tagged **documentation** `0.2.0` on 2026-08-14 (process + specs). The **application** `0.2.0` is the next feature slice on `gym-buddy-service`, `gym-buddy-ui`, and `gym-buddy-openapi`.
+
+| Tag | Artifact | Meaning |
+| --- | --- | --- |
+| `0.1.0` | Docs + service | Assignment text; pipeline probe |
+| `0.1.1` | Service | GHCR + VPS probe replace |
+| `0.2.0` | Docs (2026-08-14) | Wiki process, specs, Gitflow, CI/CD contract |
+| **`0.2.0` (application, planned)** | Service + UI + OpenAPI | PostgreSQL 18, Redis, MinIO, **Java 26 / Spring Boot service layer**, basic **sign-up / sign-in / log-out** pages. Local compose already specified. |
+| `1.0.0` | All four repos, same day | Academic ship |
+
+Application `0.2.0` is done when all of these are true on `develop` and then tagged on `main` via Release:
+
+1. `gym-buddy-service` is a Spring Boot app (Java 26) with Flyway, `GET /api/v1/healthz` and `GET /api/v1/readyz`
+2. Local `compose.yaml` runs PostgreSQL 18, Redis, MinIO, and that API on `127.0.0.1`
+3. OpenAPI documents register / login / logout / refresh under `/api/v1/auth` (`healthz` / `readyz` replace the stub `/health`)
+4. JWT access + refresh as in [../40-Technical-specifications/02-JWT-authentication.md](../40-Technical-specifications/02-JWT-authentication.md); logout denylists refresh `jti` in Redis
+5. `gym-buddy-ui` has a basic sign-up, sign-in, and log-out page that call that API
+6. Each repo changelog records the slice under `## [0.2.0]`
+
+Out of scope for application `0.2.0`: friends, feed, events, search, chat, admin lock/role UI, production data-plane on the VPS.
+
 ## Who picks the number
 
 The Release workflow computes the next version unless you type one.
@@ -35,6 +58,8 @@ The Release workflow computes the next version unless you type one.
 | `gh workflow run Release -f bump=minor` | Force that bump from the latest `v*` tag |
 | `gh workflow run Release -f version=0.4.0` | Use **exactly** `0.4.0` (must be greater than the latest tag) |
 | `gh workflow run Release -f version=1.0.0` | Academic ship. **`1.0.0` is never chosen automatically** |
+
+For the application slice, pin the number: `gh workflow run Release -f version=0.2.0` on each of service, UI, and OpenAPI when that slice is on `develop`.
 
 The number is written as an annotated git tag `vX.Y.Z` on the squash commit on `main`.
 
@@ -55,7 +80,7 @@ Before `1.0.0`, anything may change; we still record those changes in the change
 | OpenAPI contract (`gym-buddy-openapi`) | Yes | This **is** the public API number |
 | Backend | Yes | Implements a given contract version |
 | Frontend | Yes | Consumes a given contract version |
-| This documentation wiki | Yes | Same scheme; `0.1.0` already used |
+| This documentation wiki | Yes | Same scheme; `0.1.0` and `0.2.0` already used for the wiki contract |
 
 At `1.0.0`, tag **all four** repositories `v1.0.0` on the same day so the report can cite one number.
 
@@ -66,3 +91,5 @@ A backend must not claim `1.0.0` while it implements an OpenAPI document still a
 Each repository keeps a `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. This wiki’s file is [../90-Changelog/CHANGELOG.md](../90-Changelog/CHANGELOG.md).
 
 Move bullets from `Unreleased` to a dated `## [0.y.z]` section when the Release workflow squash-merges to `main`. The workflow does this itself (`prepare_changelog.py`).
+
+Planned application `0.2.0` work stays under `Unreleased` in this wiki until that slice is tagged on the application repos; then add a dated note here that the product slice shipped.

--- a/70-Engineering-practices/08-Feature-implementation.md
+++ b/70-Engineering-practices/08-Feature-implementation.md
@@ -59,17 +59,21 @@ Open a GitHub Issue on **`gym-buddy-documentation`** using the existing template
 
 The form **automatically adds the issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1)** (`projects: Projet-de-compensation-2025-2026/1`). That is required, not optional. Confirm the checkbox. Do not remove the issue from the board afterwards.
 
-If you create an issue without the form, attach it to the project in the same step. An issue that exists only in the repo issues list is not a ticket yet.
+The form also requires **`70-Engineering-practices`**. That directory is the org-wide source of truth for code style, Gitflow / Conventional Commits, pull requests, tickets, versioning, and CI/CD. Every implementation in every repository follows it. Agents do not invent a parallel workflow.
+
+If you create an issue without the form, attach it to the project **and** cite `70-Engineering-practices` in the same step. An issue that exists only in the repo issues list is not a ticket yet.
 
 | Template field | What to put |
 | --- | --- |
 | Title | `[GB] ` plus one imperative outcome |
 | Type | Feature, Bug, Chore, or Docs |
-| Documentation page | Relative path(s) in **this** wiki. Required. Example: `30-Functional-specifications/07-Events.md`. Add the matching technical page when one exists. |
+| Documentation page | Relative path(s) of the **feature** spec in **this** wiki. Required. Example: `30-Functional-specifications/07-Events.md`. Add the matching technical page when one exists. |
+| Engineering practices | Always `70-Engineering-practices`. Required. |
 | Spec IDs | `FS-…` / `TS-…` from those pages |
 | Implementation repository | Every repo that will change (`gym-buddy-documentation`, `gym-buddy-service`, `gym-buddy-ui`, `gym-buddy-openapi`) |
 | Acceptance | Checklist copied or cited from the linked spec |
 | Gym Buddy Project | Required checkbox. The form already attaches the issue. |
+| Follow engineering practices | Required checkbox. |
 
 The ticket **must** point at the documentation it implements. A title such as “implement events” with no wiki path is incomplete — go back to step 3.
 

--- a/70-Engineering-practices/README.md
+++ b/70-Engineering-practices/README.md
@@ -1,6 +1,8 @@
 # 70 — Engineering practices
 
-How we write, review, and ship code and documentation across Gym Buddies repositories.
+How we write, review, and ship code and documentation across **every** Gym Buddies repository. This directory is the org-wide source of truth for conventions, standards, and workflows. Agents and humans follow it; they do not invent a second process.
+
+**Every ticket** must cite this directory (the issue form requires it).
 
 ## Contents
 
@@ -10,8 +12,8 @@ How we write, review, and ship code and documentation across Gym Buddies reposit
 | [02-Git-workflow.md](02-Git-workflow.md) | [Gitflow (Atlassian)](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) + [Conventional Commits](https://www.conventionalcommits.org/) |
 | [03-Review-process.md](03-Review-process.md) | What a review must check (including “does it match the wiki?”) |
 | [04-Documentation-conventions.md](04-Documentation-conventions.md) | Numbering, page template, linking, changelog entries |
-| [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md) | Issues live here, must link a wiki page, commit scope = ticket id |
-| [06-Versioning.md](06-Versioning.md) | [Semantic Versioning 2.0.0](https://semver.org/) — `0.y.z` until the academic `1.0.0` |
+| [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md) | Issues live here, must link a wiki page **and this directory**, commit scope = ticket id |
+| [06-Versioning.md](06-Versioning.md) | [Semantic Versioning 2.0.0](https://semver.org/) — `0.y.z` until the academic `1.0.0`; application `0.2.0` is the first Java + data-plane + auth slice |
 | [07-CI-CD.md](07-CI-CD.md) | GitHub Actions: CI on `develop`, Release squash+tag onto `main`, Deploy (Pages or `replace.sh`) |
 | [08-Feature-implementation.md](08-Feature-implementation.md) | Consult Joaquim → update specs → ticket on **Gym Buddy Project** → `Not Ready` / `Todo` / `In Progress` / `Done` |
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable changes to **Gym Buddies** (product) and to **this documentation repository** are recorded here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-Versioning: [Semantic Versioning](https://semver.org/).
+Versioning: [Semantic Versioning 2.0.0](https://semver.org/).
 
 Until the first application release, versions refer to the **documentation contract**. Application repos will add their own `CHANGELOG.md` and must not contradict this one on user-visible behavior.
+
+**Documentation `0.2.0` (2026-08-14) is not the application slice.** The next **product** tag on `gym-buddy-service`, `gym-buddy-ui`, and `gym-buddy-openapi` is application `0.2.0`: PostgreSQL 18, Redis, MinIO, Java 26 / Spring Boot service layer, and basic sign-up / sign-in / log-out. See [../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md).
 
 ## [Unreleased]
 
@@ -15,6 +17,8 @@ Until the first application release, versions refer to the **documentation contr
 - How to record the instructor cadrage (no invented minutes)
 - Academic report chapter map, presentation speaker notes, screenshot checklist including VPS health
 - Ticket form auto-adds every new issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1) (`projects: Projet-de-compensation-2025-2026/1`) and requires a confirmation checkbox
+- Ticket form requires [`70-Engineering-practices`](../70-Engineering-practices/README.md) on every issue (code style, git, PRs, CI/CD) so every repo and every agent follows the same workflow
+- Planned **application `0.2.0`**: PostgreSQL 18, Redis, MinIO, Java 26 / Spring Boot service layer, `healthz` / `readyz`, JWT register / login / logout, basic sign-up / sign-in / log-out pages. Out of scope: friends, feed, events, search, chat, admin UI, VPS data plane
 
 ### Changed
 
@@ -25,8 +29,12 @@ Until the first application release, versions refer to the **documentation contr
 - Technology-choices cadence row: Approved
 - Changelog compare links point at this repository
 - Tickets: attaching to Gym Buddy Project is required at creation, not later
+- Tickets: citing `70-Engineering-practices` is required at creation
+- Versioning: application `0.2.0` is defined as the first Java + data-plane + auth slice (distinct from documentation `0.2.0`)
 
 ## [0.2.0] — 2026-08-14
+
+Documentation contract only (process + specs). Not the Java application.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Ticket form now **requires** `70-Engineering-practices` (dedicated field + checkbox) so code style, Gitflow, PRs, and CI/CD stay the same across repos and agents
- Process pages (`05`, `08`, directory README) match
- Changelog + versioning define **application `0.2.0`**: PostgreSQL 18, Redis, MinIO, Java 26 / Spring service layer, basic sign-up / sign-in / log-out
- Honest about documentation `0.2.0` (2026-08-14) already existing as a wiki contract

## Test plan

- [ ] New issue → Ticket shows Engineering practices field and both required checkboxes
- [ ] Versioning planned-slices table is readable
- [ ] Changelog Unreleased names application 0.2.0 without rewriting the dated docs 0.2.0 section
