### PR TITLE
[#11] Align wiki with healthz/readyz OpenAPI stub

### DIFF
--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -14,7 +14,7 @@ Be honest at the defense. The pipeline, the VPS, and the **local data plane** ex
 | Piece | Today (August 2026) | Target (locked) |
 | --- | --- | --- |
 | `gym-buddy-service` | Python 3.12 probe (`python:3.12-alpine`). Serves `probe/index.html` on port 8080. `compose.yaml` and `.env.example` are in the repo. No `pom.xml`. Latest released tag **v0.1.1**. | Java 26 / Spring Boot modular monolith |
-| `gym-buddy-openapi` | OpenAPI 3.1.0 stub: `GET /health` under `/api/v1` | Full contract; health becomes `GET /api/v1/healthz` and `GET /api/v1/readyz` |
+| `gym-buddy-openapi` | OpenAPI 3.1.0 stub: `GET /healthz` and `GET /readyz` under `/api/v1` | Full contract; health stays `GET /api/v1/healthz` and `GET /api/v1/readyz` |
 | `gym-buddy-ui` | Static HTML probe | Angular 22 member app + back-office |
 | Health | Probe answers `GET /`. Smoke looks for the string `Gym Buddy`. | Unauthenticated `GET /api/v1/healthz` (liveness) and `GET /api/v1/readyz` (PostgreSQL + object storage reachable) |
 | Local data plane | `compose.yaml` in `gym-buddy-service`: Postgres 18, Redis, MinIO, probe API, optional MailHog. All binds `127.0.0.1`. | Same file; API service becomes the Spring image |
@@ -165,9 +165,9 @@ If the three SSH secrets are missing, Deploy still pushes the image and **skips*
 | When | What the smoke hits |
 | --- | --- |
 | Today (probe, no `pom.xml`) | `GET /` on the container. Body must contain `Gym Buddy`. |
-| Target (Spring + contract update) | `GET /api/v1/healthz` and `GET /api/v1/readyz`, unauthenticated. |
+| Target (when `pom.xml` exists) | `GET /api/v1/healthz` and `GET /api/v1/readyz`, unauthenticated. |
 
-The OpenAPI stub still documents `GET /api/v1/health`. That is a known disagreement. The locked decision is `healthz` / `readyz`. Change the stub and the smoke script in the same ticket that adds Spring.
+The OpenAPI stub now documents `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11 / [gym-buddy-openapi#2](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi/pull/2)). The probe still answers `GET /`. Switch the smoke script when `pom.xml` appears. Target smoke remains `healthz` / `readyz`.
 
 ## VPS
 
@@ -210,7 +210,7 @@ Let’s Encrypt **HTTP-01** needs port **80** reachable from the world for a few
 | Work | Where |
 | --- | --- |
 | Flyway, Spring Boot | `gym-buddy-service` |
-| Expand OpenAPI past `GET /health`; rename health to `healthz` / `readyz` | `gym-buddy-openapi` |
+| Expand the OpenAPI contract past `healthz` / `readyz` | `gym-buddy-openapi` |
 | Angular 22 apps | `gym-buddy-ui` |
 | Smoke script switch from `GET /` | `.github/scripts/ci/smoke.sh` in the service repo, when `pom.xml` appears |
 | Private data-plane compose on the VPS | Operator work after the API needs a database |

--- a/40-Technical-specifications/01-API-conventions.md
+++ b/40-Technical-specifications/01-API-conventions.md
@@ -66,7 +66,7 @@ Do not publish `/actuator/health` as the contract. Actuator may exist internally
 | Surface | Path today | Action |
 | --- | --- | --- |
 | Probe image in `gym-buddy-service` | `GET /` (HTML) | Keep until `pom.xml` exists; then smoke `/api/v1/healthz` |
-| `gym-buddy-openapi` stub | `GET /api/v1/health` | Replace with `healthz` + `readyz` in the same ticket that introduces Spring |
-| This page | `healthz` / `readyz` | Source of truth for the target |
+| `gym-buddy-openapi` stub | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Already renamed (openapi #2 / ticket #11). The service does not implement them yet. |
+| This page | `healthz` / `readyz` | Source of truth for the health contract |
 
 CI smoke scripts change when the service stops being a probe.

--- a/40-Technical-specifications/08-OpenAPI-contract.md
+++ b/40-Technical-specifications/08-OpenAPI-contract.md
@@ -24,9 +24,9 @@ The HTTP API is specified in a **dedicated repository**, not discovered from a r
 | | Today | Target |
 | --- | --- | --- |
 | Document | OpenAPI 3.1.0 stub | Full `/api/v1` |
-| Health | `GET /api/v1/health` | `GET /api/v1/healthz` and `GET /api/v1/readyz` |
+| Health | `GET /api/v1/healthz` and `GET /api/v1/readyz` | `GET /api/v1/healthz` and `GET /api/v1/readyz` |
 
-Change the stub in the same ticket that introduces Spring. Locked paths: [01-API-conventions.md](01-API-conventions.md).
+Locked paths: [01-API-conventions.md](01-API-conventions.md). The service does not implement them yet.
 
 ## Why not “just expose `/v3/api-docs`”
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -34,6 +34,7 @@ Until the first application release, versions refer to the **documentation contr
 - Versioning: application `0.2.0` is defined as the first Java + data-plane + auth slice (distinct from documentation `0.2.0`)
 - Runbook today-vs-target: local compose is in the service repo; Spring / Flyway still absent
 - Tickets: Atlas (ops agent) owns `Not Ready` → `Todo` and `In Progress` → `Done`; Done requires Sentinel confirmation against functional requirements in this wiki. Joaquim remains product owner for consult / scope and no longer makes those two board moves by hand.
+- OpenAPI stub and wiki now agree on `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11); probe smoke is still `GET /` until Spring
 
 ## [0.2.0] — 2026-08-14
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wiki-only follow-up for ticket [#11](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/issues/11). [gym-buddy-openapi#2](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi/pull/2) already renamed the stub to `GET /api/v1/healthz` and `GET /api/v1/readyz`. This PR makes the wiki match that stub.

Refs: Projet-de-compensation-2025-2026/gym-buddy-documentation#11

- `01-API-conventions.md` remains the source of truth for `healthz` / `readyz`. The OpenAPI stub row now records those paths (openapi #2 / ticket #11). The probe image stays `GET /` (HTML) until `pom.xml` exists. The service still does not implement the health routes.
- `04-Environment-and-pipeline.md` drops the “known disagreement” on `GET /api/v1/health`. Today’s stub is `healthz` / `readyz`; smoke stays `GET /` until `pom.xml` appears; remaining OpenAPI work is expanding the contract past those two paths (rename is done).
- `08-OpenAPI-contract.md` Today health is `healthz` / `readyz`. Removed “change the stub in the same ticket that introduces Spring.”
- Changelog Unreleased: stub and wiki now agree; probe smoke is still `GET /` until Spring.

Does **not** claim Spring Boot, Flyway, Actuator, or `pom.xml` exist in `gym-buddy-service`. Does not edit application repos. Does not close ticket #11.

## Test plan

- [ ] Diff is only the four wiki/changelog files above
- [ ] No page claims Spring / Flyway / Actuator / `pom.xml` exist
- [ ] Probe smoke is still documented as `GET /`
- [ ] Target smoke remains `GET /api/v1/healthz` and `GET /api/v1/readyz`
- [ ] Ticket #11 stays open

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5147cdfa-622f-47ae-82cd-86e0c7856692?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5147cdfa-622f-47ae-82cd-86e0c7856692&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

