### PR TITLE
Atlas owns Not Ready→Todo and In Progress→Done

### DIFF
--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -16,7 +16,9 @@ body:
            repository and every agent. Do not invent a second workflow.
 
         **This form adds the issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1).**
-        Status starts at **Not Ready**; only Joaquim Kéloglanian moves it to **Todo** after an explicit review.
+        Status starts at **Not Ready**. **Atlas** (the non-coding ops agent) owns **Not Ready** → **Todo**.
+        **Atlas** owns **In Progress** → **Done** after **Sentinel** (the tests/review agent) confirms
+        the work was implemented and satisfies the functional requirements in this wiki.
 
         Start here: [`70-Engineering-practices`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/tree/develop/70-Engineering-practices).
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -16,9 +16,11 @@ body:
            repository and every agent. Do not invent a second workflow.
 
         **This form adds the issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1).**
-        Status starts at **Not Ready**. **Atlas** (the non-coding ops agent) owns **Not Ready** → **Todo**.
-        **Atlas** owns **In Progress** → **Done** after **Sentinel** (the tests/review agent) confirms
-        the work was implemented and satisfies the functional requirements in this wiki.
+        Status starts at **Not Ready**.
+
+        Atlas alone sets **Not Ready** → **Todo**.
+        Atlas sets **In Progress** → **Done** only after Sentinel confirms the work was implemented
+        and satisfies the functional requirements. No other transitions.
 
         Start here: [`70-Engineering-practices`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/tree/develop/70-Engineering-practices).
   - type: dropdown

--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -220,4 +220,4 @@ Let’s Encrypt **HTTP-01** needs port **80** reachable from the world for a few
 
 ## Feature workflow
 
-Wiki first, ticket on this documentation repo, Joaquim sets `Todo`. Full sequence: [../70-Engineering-practices/08-Feature-implementation.md](../70-Engineering-practices/08-Feature-implementation.md).
+Wiki first, ticket on this documentation repo, Atlas sets `Todo`. Full sequence: [../70-Engineering-practices/08-Feature-implementation.md](../70-Engineering-practices/08-Feature-implementation.md).

--- a/70-Engineering-practices/03-Review-process.md
+++ b/70-Engineering-practices/03-Review-process.md
@@ -10,7 +10,7 @@ Even on an individual project, every merge to `develop` (features) or `main` (re
 ## Checklist
 
 - [ ] Ticket exists on `gym-buddy-documentation`, is on **Gym Buddy Project**, and **links a wiki page** ([05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md), [08-Feature-implementation.md](08-Feature-implementation.md)) — or the commit has **no** ticket id in the scope
-- [ ] Ticket is `In Progress` while the PR is open; it becomes `Done` only after the merge to `develop`
+- [ ] Ticket is `In Progress` while the PR is open; it becomes `Done` only after the merge to `develop`. Atlas sets `Done` after Sentinel confirms
 - [ ] Commit scopes follow [02-Git-workflow.md](02-Git-workflow.md): `(#42)` if there is a ticket, topical otherwise
 - [ ] `Refs: <owner>/gym-buddy-documentation#<id>` in the commit/PR body when a ticket exists
 - [ ] Spec IDs in the description (`FS-…`, `TS-…`)

--- a/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
+++ b/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
@@ -79,10 +79,10 @@ Exactly four. These replace any older Backlog / Ready / In review layout.
 
 | Status | Meaning |
 | --- | --- |
-| `Not Ready` | Default at creation. Specs and template are filled; Joaquim has not green-lit implementation |
-| `Todo` | Joaquim Kéloglanian has read, reviewed, and explicitly approved the ticket |
+| `Not Ready` | Default at creation. Specs and template are filled; not yet set to `Todo` |
+| `Todo` | Atlas has set `Todo`: the ticket and linked specs are complete enough to implement |
 | `In Progress` | Implementation of this ticket has started |
-| `Done` | Implemented, tested, formatted, and merged into `develop` |
+| `Done` | Implemented, tested, formatted, and merged into `develop`. Atlas sets `Done` after Sentinel confirms |
 
 Rules and the full feature sequence: [08-Feature-implementation.md](08-Feature-implementation.md).
 

--- a/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
+++ b/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
@@ -77,12 +77,14 @@ If there is no ticket, **do not** put a ticket number in the commit scope. Use a
 
 Exactly four. These replace any older Backlog / Ready / In review layout.
 
-| Status | Meaning |
-| --- | --- |
-| `Not Ready` | Default at creation. Specs and template are filled; not yet set to `Todo` |
-| `Todo` | Atlas has set `Todo`: the ticket and linked specs are complete enough to implement |
-| `In Progress` | Implementation of this ticket has started |
-| `Done` | Implemented, tested, formatted, and merged into `develop`. Atlas sets `Done` after Sentinel confirms |
+Atlas alone sets `Not Ready` → `Todo`. Atlas sets `In Progress` → `Done` only after Sentinel confirms the work was implemented and satisfies the functional requirements. No other transitions.
+
+| Status | Meaning | Who sets it |
+| --- | --- | --- |
+| `Not Ready` | Default at creation. Specs and template are filled; not yet set to `Todo` | Default at creation |
+| `Todo` | The ticket and linked specs are complete enough to implement | Atlas alone (`Not Ready` → `Todo`) |
+| `In Progress` | Implementation of this ticket has started | Whoever starts the work |
+| `Done` | Implemented, tested, formatted, and merged into `develop` | Atlas (`In Progress` → `Done`), only after Sentinel confirms |
 
 Rules and the full feature sequence: [08-Feature-implementation.md](08-Feature-implementation.md).
 

--- a/70-Engineering-practices/08-Feature-implementation.md
+++ b/70-Engineering-practices/08-Feature-implementation.md
@@ -9,6 +9,13 @@ How a feature goes from an idea in the assignment (or a later request) to a merg
 
 The product owner is **Joaquim Kéloglanian**. He owns consult and scope (step 1). He does not move tickets `Not Ready` → `Todo` or `In Progress` → `Done` by hand.
 
+**Who moves the board:**
+
+- **Atlas alone** sets `Not Ready` → `Todo`.
+- **Atlas** sets `In Progress` → `Done` only after **Sentinel** confirms the work was implemented and satisfies the functional requirements.
+
+No other transitions. `Todo` → `In Progress` is still whoever starts the work.
+
 ## Sequence
 
 ```mermaid
@@ -85,16 +92,18 @@ Newly created tickets default to **`Not Ready`**.
 
 There are exactly four. They are the Status field on **Gym Buddy Project**. Do not invent extra columns (`Backlog`, `Ready`, `In review`, …).
 
+Atlas alone sets `Not Ready` → `Todo`. Atlas sets `In Progress` → `Done` only after Sentinel confirms the work was implemented and satisfies the functional requirements. No other transitions.
+
 | Status | Meaning | Who may set it |
 | --- | --- | --- |
 | `Not Ready` | Ticket exists, every template field is filled, it is on **Gym Buddy Project**, and it points at wiki pages. It is **not** approved for implementation. | Default at creation |
-| `Todo` | The ticket and linked specs are complete enough to implement | **Atlas** only |
+| `Todo` | The ticket and linked specs are complete enough to implement | Atlas alone (`Not Ready` → `Todo`) |
 | `In Progress` | Implementation of this ticket has started (branch, first commit, or first draft PR) | Whoever starts the work, **as soon as** it starts |
-| `Done` | The change is implemented, tested, formatted, and **merged into `develop`** | **Atlas**, after Sentinel confirms implementation vs functional requirements in this wiki |
+| `Done` | The change is implemented, tested, formatted, and **merged into `develop`** | Atlas (`In Progress` → `Done`), only after Sentinel confirms |
 
 ### `Not Ready` → `Todo`
 
-**Atlas** (the non-coding ops agent) sets `Todo` when the ticket and linked specs are complete enough to implement. Joaquim does not move this by hand.
+Atlas alone sets `Not Ready` → `Todo`. Atlas (the non-coding ops agent) does this when the ticket and linked specs are complete enough to implement. Joaquim does not move this by hand.
 
 Sentinel does not gate this move: nothing is implemented yet. A verbal “looks fine, go” in the consult (step 1) is not this board change; that consult happens *before* the specs and the ticket exist.
 
@@ -113,7 +122,7 @@ A ticket becomes `Done` when **all** of these are true:
 3. Format checks pass (CI `format` / [07-CI-CD.md](07-CI-CD.md))
 4. The PR is merged into **`develop`**
 
-**Atlas** is who sets `Done`, and only after **Sentinel** (the tests/review agent) confirms the work was implemented and satisfies the linked functional requirements in this wiki.
+Atlas sets `In Progress` → `Done` only after Sentinel (the tests/review agent) confirms the work was implemented and satisfies the functional requirements. Joaquim does not move this by hand.
 
 A green CI run on an open PR is not `Done`. A squash onto `main` (a Release) is not what closes the ticket. Tickets close on `develop`; Release packages whatever is already there.
 

--- a/70-Engineering-practices/08-Feature-implementation.md
+++ b/70-Engineering-practices/08-Feature-implementation.md
@@ -7,7 +7,7 @@
 
 How a feature goes from an idea in the assignment (or a later request) to a merge on `develop`. This page is the process. Ticket fields live in [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md). Git and CI rules stay on their own pages.
 
-The product owner is **Joaquim Kéloglanian**. No ticket moves to `Todo`, and no implementation starts, without his explicit green light.
+The product owner is **Joaquim Kéloglanian**. He owns consult and scope (step 1). He does not move tickets `Not Ready` → `Todo` or `In Progress` → `Done` by hand.
 
 ## Sequence
 
@@ -18,12 +18,12 @@ flowchart TD
   specs[3. Update functional and technical specifications]
   ticket[4. Open a ticket from the template]
   notReady[Status: Not Ready]
-  review[Joaquim reads, reviews, green-lights]
+  review[Atlas sets Todo]
   todo[Status: Todo]
   start[5. Implementation starts]
   inProgress[Status: In Progress]
   land[6. Implemented, tested, formatted, merged to develop]
-  done[Status: Done]
+  done[Status: Done — Atlas after Sentinel confirms]
 
   consult --> mature --> specs --> ticket --> notReady
   notReady --> review --> todo --> start --> inProgress --> land --> done
@@ -88,19 +88,15 @@ There are exactly four. They are the Status field on **Gym Buddy Project**. Do n
 | Status | Meaning | Who may set it |
 | --- | --- | --- |
 | `Not Ready` | Ticket exists, every template field is filled, it is on **Gym Buddy Project**, and it points at wiki pages. It is **not** approved for implementation. | Default at creation |
-| `Todo` | Joaquim Kéloglanian has **explicitly** read the ticket, reviewed the linked specs, and given the green light | **Only** Joaquim, after that review |
+| `Todo` | The ticket and linked specs are complete enough to implement | **Atlas** only |
 | `In Progress` | Implementation of this ticket has started (branch, first commit, or first draft PR) | Whoever starts the work, **as soon as** it starts |
-| `Done` | The change is implemented, tested, formatted, and **merged into `develop`** | After the merge to `develop` (CI green — see [07-CI-CD.md](07-CI-CD.md)) |
+| `Done` | The change is implemented, tested, formatted, and **merged into `develop`** | **Atlas**, after Sentinel confirms implementation vs functional requirements in this wiki |
 
 ### `Not Ready` → `Todo`
 
-Filling the template is not a green light. `Todo` is set **only** when Joaquim has:
+**Atlas** (the non-coding ops agent) sets `Todo` when the ticket and linked specs are complete enough to implement. Joaquim does not move this by hand.
 
-1. Read the ticket
-2. Reviewed the linked documentation
-3. Said explicitly that implementation may start
-
-Nobody else promotes a ticket to `Todo`. A verbal “looks fine, go” in the consult (step 1) does **not** skip this review: that consult happens *before* the specs and the ticket exist.
+Sentinel does not gate this move: nothing is implemented yet. A verbal “looks fine, go” in the consult (step 1) is not this board change; that consult happens *before* the specs and the ticket exist.
 
 ### `Todo` → `In Progress`
 
@@ -116,6 +112,8 @@ A ticket becomes `Done` when **all** of these are true:
 2. Tests required by that spec (and [80-Testing](../80-Testing/README.md)) exist and pass
 3. Format checks pass (CI `format` / [07-CI-CD.md](07-CI-CD.md))
 4. The PR is merged into **`develop`**
+
+**Atlas** is who sets `Done`, and only after **Sentinel** (the tests/review agent) confirms the work was implemented and satisfies the linked functional requirements in this wiki.
 
 A green CI run on an open PR is not `Done`. A squash onto `main` (a Release) is not what closes the ticket. Tickets close on `develop`; Release packages whatever is already there.
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -33,6 +33,7 @@ Until the first application release, versions refer to the **documentation contr
 - Tickets: citing `70-Engineering-practices` is required at creation
 - Versioning: application `0.2.0` is defined as the first Java + data-plane + auth slice (distinct from documentation `0.2.0`)
 - Runbook today-vs-target: local compose is in the service repo; Spring / Flyway still absent
+- Tickets: Atlas (ops agent) owns `Not Ready` → `Todo` and `In Progress` → `Done`; Done requires Sentinel confirmation against functional requirements in this wiki. Joaquim remains product owner for consult / scope and no longer makes those two board moves by hand.
 
 ## [0.2.0] — 2026-08-14
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Joaquim authorized a process change: he no longer manually moves tickets `Not Ready` → `Todo` or `In Progress` → `Done`. Atlas (the non-coding ops agent) owns those two board moves. Before Atlas sets `Done`, Atlas must confirm with Sentinel (the tests/review agent) that the work was implemented and satisfies the functional requirements in this wiki.

The owner split is stated in plain language, not only in a table cell:

- Atlas alone sets `Not Ready` → `Todo`.
- Atlas sets `In Progress` → `Done` only after Sentinel confirms the work was implemented and satisfies the functional requirements.
- No other transitions. `Todo` → `In Progress` is still whoever starts the work.

Joaquim remains product owner for consult / scope (step 1). There is no Sentinel implementation gate on `Not Ready` → `Todo`.

## Source-of-truth updates

- `70-Engineering-practices/08-Feature-implementation.md` — opening “Who moves the board” list, Statuses intro, mermaid, and the two transition sections
- `70-Engineering-practices/05-Tickets-and-GitHub-projects.md` — the same two sentences above the board table, plus a Who column
- `.github/ISSUE_TEMPLATE/ticket.yml` — the same two sentences on the ticket form
- `70-Engineering-practices/03-Review-process.md` — Done checklist line
- `10-Getting-started/04-Environment-and-pipeline.md` — Feature workflow footer only (`Atlas sets Todo`)
- `90-Changelog/CHANGELOG.md` — one Unreleased Changed bullet

`70-Engineering-practices/README.md` was left unchanged: the one-line summary still starts with consult Joaquim and does not imply Joaquim-only `Todo`.

This PR does not close or retitle existing tickets, does not edit application repos, and does not claim Spring / Flyway / `pom.xml` exist.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e12734a5-7087-4f9a-9bda-a5cd68a8f124?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e12734a5-7087-4f9a-9bda-a5cd68a8f124&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

