### PR TITLE
Approve Java 25 LTS instead of Java 26

### DIFF
--- a/10-Getting-started/02-Related-repositories.md
+++ b/10-Getting-started/02-Related-repositories.md
@@ -11,7 +11,7 @@ Gym Buddies is documented **once** here and implemented in **three** other repos
 | --- | --- | --- | --- | --- |
 | `gym-buddy-documentation` (this repo) | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation | Public | Product, architecture, specs, practices, academic packaging, **tickets** | GitHub Pages (Markdown → Jekyll) |
 | `gym-buddy-openapi` | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi | Private | Versioned OpenAPI 3 contract + static Swagger/Redoc | GitHub Pages when the plan allows (static) |
-| `gym-buddy-service` | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service | Private | Java API, domain, jobs, WebSocket, fixtures (Python probe until Spring exists) | OVH VPS — see [04-Environment-and-pipeline.md](04-Environment-and-pipeline.md) |
+| `gym-buddy-service` | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service | Private | Java 25 LTS / Spring Boot API (`pom.xml` on `develop`), domain, jobs, WebSocket, fixtures | OVH VPS — see [04-Environment-and-pipeline.md](04-Environment-and-pipeline.md) |
 | `gym-buddy-ui` | https://github.com/Projet-de-compensation-2025-2026/gym-buddy-ui | Private | Angular member app **and** Angular back-office | GitHub Pages (static `ng build`) |
 
 Default branch on every repository: **`develop`**. Feature work never targets `main`.
@@ -29,7 +29,7 @@ The contract is a **git artifact**, not a runtime accident:
 
 Spring may still expose `/v3/api-docs` in development as a convenience. That endpoint is **not** the source of truth. If it disagrees with `gym-buddy-openapi`, the repository wins.
 
-Today the OpenAPI repo is a stub (`GET /api/v1/healthz` and `GET /api/v1/readyz`). Those remain the target health paths — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md).
+Today the OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz`. Those remain the public health paths — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md). The public contract is not `/actuator/health`.
 
 ## Rules for application repos
 
@@ -43,7 +43,7 @@ Today the OpenAPI repo is a stub (`GET /api/v1/healthz` and `GET /api/v1/readyz`
 ```
 gym-buddy-documentation/     ← you are here (wiki + GitHub Project)
 gym-buddy-openapi/           ← HTTP contract
-gym-buddy-service/           ← Java 25 LTS + Spring Boot (probe image until then)
+gym-buddy-service/           ← Java 25 LTS + Spring Boot (`pom.xml` on develop)
 gym-buddy-ui/                ← Angular 22 (member + back-office)
 ```
 

--- a/10-Getting-started/02-Related-repositories.md
+++ b/10-Getting-started/02-Related-repositories.md
@@ -29,7 +29,7 @@ The contract is a **git artifact**, not a runtime accident:
 
 Spring may still expose `/v3/api-docs` in development as a convenience. That endpoint is **not** the source of truth. If it disagrees with `gym-buddy-openapi`, the repository wins.
 
-Today the OpenAPI repo is a stub (`GET /api/v1/health` only). Target health paths are `/api/v1/healthz` and `/api/v1/readyz` — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md).
+Today the OpenAPI repo is a stub (`GET /api/v1/healthz` and `GET /api/v1/readyz`). Those remain the target health paths — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md).
 
 ## Rules for application repos
 
@@ -43,7 +43,7 @@ Today the OpenAPI repo is a stub (`GET /api/v1/health` only). Target health path
 ```
 gym-buddy-documentation/     ← you are here (wiki + GitHub Project)
 gym-buddy-openapi/           ← HTTP contract
-gym-buddy-service/           ← Java 26 + Spring Boot (probe image until then)
+gym-buddy-service/           ← Java 25 LTS + Spring Boot (probe image until then)
 gym-buddy-ui/                ← Angular 22 (member + back-office)
 ```
 

--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -13,7 +13,7 @@ Be honest at the defense. The pipeline, the VPS, and the **local data plane** ex
 
 | Piece | Today (August 2026) | Target (locked) |
 | --- | --- | --- |
-| `gym-buddy-service` | Python 3.12 probe (`python:3.12-alpine`). Serves `probe/index.html` on port 8080. `compose.yaml` and `.env.example` are in the repo. No `pom.xml`. Latest released tag **v0.1.1**. | Java 26 / Spring Boot modular monolith |
+| `gym-buddy-service` | Python 3.12 probe (`python:3.12-alpine`). Serves `probe/index.html` on port 8080. `compose.yaml` and `.env.example` are in the repo. No `pom.xml`. Latest released tag **v0.1.1**. | Java 25 LTS / Spring Boot modular monolith |
 | `gym-buddy-openapi` | OpenAPI 3.1.0 stub: `GET /healthz` and `GET /readyz` under `/api/v1` | Full contract; health stays `GET /api/v1/healthz` and `GET /api/v1/readyz` |
 | `gym-buddy-ui` | Static HTML probe | Angular 22 member app + back-office |
 | Health | Probe answers `GET /`. Smoke looks for the string `Gym Buddy`. | Unauthenticated `GET /api/v1/healthz` (liveness) and `GET /api/v1/readyz` (PostgreSQL + object storage reachable) |
@@ -27,7 +27,7 @@ Do not claim Spring, Flyway, or Actuator exist until `pom.xml` is in `gym-buddy-
 
 When Spring work starts, a laptop is ready when all of these are true:
 
-1. **JDK 26** installed (Java 25 LTS is the fallback if a library does not run on 26 — see [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md)).
+1. **JDK 25 LTS** installed (see [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md)).
 2. **Docker** and Compose v2 available.
 3. Clone the four repositories (URLs in [02-Related-repositories.md](02-Related-repositories.md)). Default branch is `develop` everywhere.
 4. `compose.yaml` and `.env.example` are in `gym-buddy-service` (ticket #7).

--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -9,23 +9,23 @@ How to run Gym Buddies locally, how a change is proven and released, and how the
 
 ## Today versus target
 
-Be honest at the defense. The pipeline, the VPS, and the **local data plane** exist. Spring Boot does **not**.
+Be honest at the defense. The pipeline, the VPS, the **local data plane**, and the **Java 25 LTS / Spring Boot** service exist on `develop` (`pom.xml`, ticket #11). Register / login / logout and a VPS compose do **not**.
 
 | Piece | Today (August 2026) | Target (locked) |
 | --- | --- | --- |
-| `gym-buddy-service` | Python 3.12 probe (`python:3.12-alpine`). Serves `probe/index.html` on port 8080. `compose.yaml` and `.env.example` are in the repo. No `pom.xml`. Latest released tag **v0.1.1**. | Java 25 LTS / Spring Boot modular monolith |
+| `gym-buddy-service` | Java 25 LTS / Spring Boot (`pom.xml` on `develop`). Flyway `V1__baseline.sql`. `compose.yaml` and `.env.example` are in the repo. Latest released tag **v0.1.1**. | Java 25 LTS / Spring Boot modular monolith |
 | `gym-buddy-openapi` | OpenAPI 3.1.0 stub: `GET /healthz` and `GET /readyz` under `/api/v1` | Full contract; health stays `GET /api/v1/healthz` and `GET /api/v1/readyz` |
 | `gym-buddy-ui` | Static HTML probe | Angular 22 member app + back-office |
-| Health | Probe answers `GET /`. Smoke looks for the string `Gym Buddy`. | Unauthenticated `GET /api/v1/healthz` (liveness) and `GET /api/v1/readyz` (PostgreSQL + object storage reachable) |
-| Local data plane | `compose.yaml` in `gym-buddy-service`: Postgres 18, Redis, MinIO, probe API, optional MailHog. All binds `127.0.0.1`. | Same file; API service becomes the Spring image |
+| Health | Service implements unauthenticated `GET /api/v1/healthz` (liveness) and `GET /api/v1/readyz` (`200` or `503` with `details` for `postgres` / `objectStorage`). CI smoke hits **`GET /api/v1/healthz` only** — the smoke image is built without Postgres/MinIO. Probe `GET /` is not today’s service smoke. | Same public paths. Do not smoke `/actuator/health`. |
+| Local data plane | `compose.yaml` in `gym-buddy-service`: Postgres 18, Redis, MinIO, Spring API, optional MailHog. All binds `127.0.0.1`. | Same file |
 | VM | One API container, bound to `127.0.0.1:8080`. Caddy terminates TLS. No compose on the VM. | Same API replace, plus a **private** data-plane compose on the Docker network (5432 / 6379 / 9000 not published) |
-| Production object storage | Not applicable (probe has none) | API **refuses to start** in production if S3-compatible storage is missing |
+| Production object storage | `SPRING_PROFILES_ACTIVE=prod` **refuses to start** if S3-compatible storage is missing | Same |
 
-Do not claim Spring, Flyway, or Actuator exist until `pom.xml` is in `gym-buddy-service`. Smoke scripts change when that file appears.
+Public health is `healthz` / `readyz`, not `/actuator/health`.
 
 ## Ready-to-code checklist
 
-When Spring work starts, a laptop is ready when all of these are true:
+A laptop is ready when all of these are true:
 
 1. **JDK 25 LTS** installed (see [../20-Architecture/07-Technology-choices.md](../20-Architecture/07-Technology-choices.md)).
 2. **Docker** and Compose v2 available.
@@ -33,11 +33,11 @@ When Spring work starts, a laptop is ready when all of these are true:
 4. `compose.yaml` and `.env.example` are in `gym-buddy-service` (ticket #7).
 5. Copy `.env.example` to `.env` locally. Fill secrets there. Never commit `.env`.
 6. `docker compose up -d` binds every published port to `127.0.0.1`.
-7. Flyway applies the schema from [../20-Architecture/06-Data-model.md](../20-Architecture/06-Data-model.md).
+7. Flyway **V1 baseline** is on `develop`. Full domain tables from [../20-Architecture/06-Data-model.md](../20-Architecture/06-Data-model.md) are later.
 8. The OpenAPI stub in `gym-buddy-openapi` is the HTTP source of truth. Expand it **before** implementing a new route.
 9. Point the UI at `http://localhost:8080/api/v1`.
 
-Until `pom.xml` exists, `docker compose up -d` starts the data plane plus the probe image. The probe does not use Postgres, Redis, or MinIO yet.
+`docker compose up -d` starts the data plane plus the Spring API. The API uses Postgres, Redis, and MinIO when those containers are up (`readyz`).
 
 ## Local Compose
 
@@ -52,7 +52,7 @@ docker compose --profile mail up -d
 
 | Service | Image role | Host bind | Port |
 | --- | --- | --- |
-| API | Spring Boot (today: the probe image) | `127.0.0.1` | `8080` |
+| API | Spring Boot (Java 25 LTS image) | `127.0.0.1` | `8080` |
 | PostgreSQL | **18** (not 19), image `postgres:18.6` | `127.0.0.1` | `5432` |
 | Redis | Cache / refresh denylist, image `redis:8-alpine` | `127.0.0.1` | `6379` |
 | MinIO | S3 API | `127.0.0.1` | `9000` |
@@ -100,7 +100,7 @@ These handles always exist after a local fixture seed. Passwords live in the loc
 | `demo.mod` | moderator |
 | `demo.admin` | admin |
 
-Flyway migrations implement [../20-Architecture/06-Data-model.md](../20-Architecture/06-Data-model.md). Fixture generation uses **Datafaker** with `FIXTURE_SEED=20260813` — [../40-Technical-specifications/07-Test-fixtures.md](../40-Technical-specifications/07-Test-fixtures.md).
+Flyway on `develop` is **V1 baseline** only. Later migrations will implement [../20-Architecture/06-Data-model.md](../20-Architecture/06-Data-model.md). Fixture generation uses **Datafaker** with `FIXTURE_SEED=20260813` — [../40-Technical-specifications/07-Test-fixtures.md](../40-Technical-specifications/07-Test-fixtures.md).
 
 ### Production refuse-without-S3
 
@@ -164,10 +164,11 @@ If the three SSH secrets are missing, Deploy still pushes the image and **skips*
 
 | When | What the smoke hits |
 | --- | --- |
-| Today (probe, no `pom.xml`) | `GET /` on the container. Body must contain `Gym Buddy`. |
-| Target (when `pom.xml` exists) | `GET /api/v1/healthz` and `GET /api/v1/readyz`, unauthenticated. |
+| Today (CI smoke) | `GET /api/v1/healthz` on the container. Body includes `"status"` and `"ok"`. The smoke image is built **without** Postgres/MinIO, so CI does **not** hit `readyz`. |
+| Today (implemented) | `GET /api/v1/readyz`: `200` when PostgreSQL and object storage are reachable, else `503` with `details` naming `postgres` and/or `objectStorage` (Testcontainers / local compose). |
+| Not today | Probe `GET /`. `/actuator/health` is not the public contract. |
 
-The OpenAPI stub now documents `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11 / [gym-buddy-openapi#2](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi/pull/2)). The probe still answers `GET /`. Switch the smoke script when `pom.xml` appears. Target smoke remains `healthz` / `readyz`.
+The OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11 / [gym-buddy-openapi#2](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi/pull/2)).
 
 ## VPS
 
@@ -209,10 +210,9 @@ Let’s Encrypt **HTTP-01** needs port **80** reachable from the world for a few
 
 | Work | Where |
 | --- | --- |
-| Flyway, Spring Boot | `gym-buddy-service` |
-| Expand the OpenAPI contract past `healthz` / `readyz` | `gym-buddy-openapi` |
+| Expand the OpenAPI contract past `healthz` / `readyz` (auth and the rest of `/api/v1`) | `gym-buddy-openapi` |
 | Angular 22 apps | `gym-buddy-ui` |
-| Smoke script switch from `GET /` | `.github/scripts/ci/smoke.sh` in the service repo, when `pom.xml` appears |
+| Sign-up / sign-in / log-out | Later ticket — not shipped |
 | Private data-plane compose on the VPS | Operator work after the API needs a database |
 | Instructor cadrage minutes | [../00-Project-brief/01-Scope-and-modules.md](../00-Project-brief/01-Scope-and-modules.md) — still **Not done** |
 

--- a/20-Architecture/03-Backend.md
+++ b/20-Architecture/03-Backend.md
@@ -5,14 +5,14 @@
 | Status | Approved |
 | Related | [01-Software-architecture.md](01-Software-architecture.md), [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
-The target backend is a single **Java 26** service (Spring Boot — see [07-Technology-choices.md](07-Technology-choices.md)) exposing HTTP and a WebSocket gateway. It **implements** the contract published in [`gym-buddy-openapi`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi); it does not own that contract.
+The approved / target backend is a single **Java 25 LTS** service (Spring Boot — see [07-Technology-choices.md](07-Technology-choices.md)) exposing HTTP and a WebSocket gateway. It **implements** the contract published in [`gym-buddy-openapi`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi); it does not own that contract. Today the service repo is still the Python probe — see the table below.
 
 ## Today versus target
 
 | | Today | Target |
 | --- | --- | --- |
-| Runtime | Python 3.12 probe image, `GET /` HTML | Java 26 / Spring Boot |
-| Contract | OpenAPI stub `GET /api/v1/health` | Full `/api/v1`, health `healthz` / `readyz` |
+| Runtime | Python 3.12 probe image, `GET /` HTML | Java 25 LTS / Spring Boot |
+| Contract | OpenAPI stub `GET /api/v1/healthz` and `GET /api/v1/readyz` | Full `/api/v1`, health `healthz` / `readyz` |
 | Data plane | None on the VPS | PostgreSQL 18, Redis, MinIO (local compose first) |
 
 Do not claim Spring is running until `pom.xml` exists in [`gym-buddy-service`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service).

--- a/20-Architecture/03-Backend.md
+++ b/20-Architecture/03-Backend.md
@@ -5,17 +5,19 @@
 | Status | Approved |
 | Related | [01-Software-architecture.md](01-Software-architecture.md), [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md), [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
-The approved / target backend is a single **Java 25 LTS** service (Spring Boot — see [07-Technology-choices.md](07-Technology-choices.md)) exposing HTTP and a WebSocket gateway. It **implements** the contract published in [`gym-buddy-openapi`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi); it does not own that contract. Today the service repo is still the Python probe — see the table below.
+The approved / target backend is a single **Java 25 LTS** service (Spring Boot — see [07-Technology-choices.md](07-Technology-choices.md)) exposing HTTP and a WebSocket gateway. It **implements** the contract published in [`gym-buddy-openapi`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi); it does not own that contract.
+
+Today [`gym-buddy-service`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service) `develop` **is** that stack: `pom.xml` exists (ticket #11). Register / login / logout are not shipped.
 
 ## Today versus target
 
 | | Today | Target |
 | --- | --- | --- |
-| Runtime | Python 3.12 probe image, `GET /` HTML | Java 25 LTS / Spring Boot |
-| Contract | OpenAPI stub `GET /api/v1/healthz` and `GET /api/v1/readyz` | Full `/api/v1`, health `healthz` / `readyz` |
-| Data plane | None on the VPS | PostgreSQL 18, Redis, MinIO (local compose first) |
+| Runtime | Java 25 LTS / Spring Boot (`pom.xml` on `develop`) | Java 25 LTS / Spring Boot modular monolith |
+| Contract | Service and OpenAPI stub: `GET /api/v1/healthz` and `GET /api/v1/readyz`. Public contract is **not** `/actuator/health`. | Full `/api/v1`; health stays `healthz` / `readyz` |
+| Data plane | Local compose (PostgreSQL 18, Redis, MinIO). Flyway **V1 baseline** only. None on the VPS | Same local compose; private data-plane compose on the VPS; full domain schema |
 
-Do not claim Spring is running until `pom.xml` exists in [`gym-buddy-service`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service).
+Do not claim register / login / logout, VPS compose, or domain tables beyond Flyway V1.
 
 ## Modules
 

--- a/20-Architecture/07-Technology-choices.md
+++ b/20-Architecture/07-Technology-choices.md
@@ -11,7 +11,7 @@ The brief requires **justification** of languages, frameworks, and libraries. La
 
 | Concern | Choice | Why this, not the alternative |
 | --- | --- | --- |
-| Backend language | **Java 26** (latest GA; JDK 26.0.2) | Course-friendly, strong typing for algorithms and JWT, long toolchain. **Java 25** is the current LTS if a library does not yet run on 26. Java 27 is not released yet (expected September 2026). |
+| Backend language | **Java 25 LTS** | Course-friendly, strong typing for algorithms and JWT, long toolchain. Current LTS; Joaquim chose 25 LTS for stability. Java 27 is not released yet (expected September 2026). |
 | Backend framework | **Spring Boot** (latest stable that supports the chosen JDK) | Modules, Spring Security for JWT, JDBC/JPA, WebSocket, Actuator health. The HTTP contract is **not** owned by Spring’s `/v3/api-docs` endpoint — see OpenAPI below. |
 | Frontend language | **TypeScript 7.0** (native compiler rewritten in [Go](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/)) | Latest TypeScript; 8–12× faster `tsc`. If Angular’s compiler lags a patch behind 7.0, use the newest TypeScript **Angular 22 supports** and record the gap in the changelog. |
 | Member UI | **Angular 22** (22.1.x as of August 2026) | Latest Angular; official TypeScript SPA; static `ng build` output can go to GitHub Pages. |
@@ -35,7 +35,7 @@ The brief requires **justification** of languages, frameworks, and libraries. La
 | Repository | Stack |
 | --- | --- |
 | `gym-buddy-documentation` | Markdown wiki (this repo), GitHub Pages |
-| `gym-buddy-service` | Java 26 + Spring Boot + PostgreSQL 18 |
+| `gym-buddy-service` | Java 25 LTS + Spring Boot + PostgreSQL 18 |
 | `gym-buddy-ui` | Angular 22 + TypeScript 7 |
 | `gym-buddy-openapi` | OpenAPI 3 documents + static reference UI |
 

--- a/20-Architecture/README.md
+++ b/20-Architecture/README.md
@@ -12,7 +12,7 @@ How Gym Buddies is split into systems, where data lives, and why the proposed st
 | [04-Frontend.md](04-Frontend.md) | Member-facing web application |
 | [05-Back-office.md](05-Back-office.md) | Admin / moderator console |
 | [06-Data-model.md](06-Data-model.md) | Relational model covering every overview feature |
-| [07-Technology-choices.md](07-Technology-choices.md) | Java 26, Angular 22, TypeScript 7, PostgreSQL 18, OpenAPI repo |
+| [07-Technology-choices.md](07-Technology-choices.md) | Java 25 LTS, Angular 22, TypeScript 7, PostgreSQL 18, OpenAPI repo |
 | [08-Hosting-and-GitHub-Pages.md](08-Hosting-and-GitHub-Pages.md) | Pages for wiki / Angular / OpenAPI UI; OVH VPS + Caddy for Java. Runbook: [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md) |
 
 Implementation details that are not architectural (JWT shape, signed URLs, fixture generation) live in [40-Technical-specifications](../40-Technical-specifications/README.md).

--- a/40-Technical-specifications/01-API-conventions.md
+++ b/40-Technical-specifications/01-API-conventions.md
@@ -61,12 +61,11 @@ Locked public contract (unauthenticated):
 
 Do not publish `/actuator/health` as the contract. Actuator may exist internally.
 
-### Drift until Spring exists
+### Today
 
-| Surface | Path today | Action |
+| Surface | Path today | Notes |
 | --- | --- | --- |
-| Probe image in `gym-buddy-service` | `GET /` (HTML) | Keep until `pom.xml` exists; then smoke `/api/v1/healthz` |
-| `gym-buddy-openapi` stub | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Already renamed (openapi #2 / ticket #11). The service does not implement them yet. |
-| This page | `healthz` / `readyz` | Source of truth for the health contract |
-
-CI smoke scripts change when the service stops being a probe.
+| `gym-buddy-service` on `develop` | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Implemented (ticket #11). `readyz` is `200` or `503` with `details` for `postgres` / `objectStorage`. |
+| CI smoke | `GET /api/v1/healthz` only | The smoke image is built without Postgres/MinIO. Probe `GET /` is not today’s smoke. |
+| `gym-buddy-openapi` stub | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Stub and service agree (openapi #2 / ticket #11). |
+| This page | `healthz` / `readyz` | Source of truth for the public health contract. Not `/actuator/health`. |

--- a/40-Technical-specifications/08-OpenAPI-contract.md
+++ b/40-Technical-specifications/08-OpenAPI-contract.md
@@ -24,9 +24,9 @@ The HTTP API is specified in a **dedicated repository**, not discovered from a r
 | | Today | Target |
 | --- | --- | --- |
 | Document | OpenAPI 3.1.0 stub | Full `/api/v1` |
-| Health | `GET /api/v1/healthz` and `GET /api/v1/readyz` | `GET /api/v1/healthz` and `GET /api/v1/readyz` |
+| Health | `GET /api/v1/healthz` and `GET /api/v1/readyz` (stub **and** service) | `GET /api/v1/healthz` and `GET /api/v1/readyz` |
 
-Locked paths: [01-API-conventions.md](01-API-conventions.md). The service does not implement them yet.
+Locked paths: [01-API-conventions.md](01-API-conventions.md). The service implements them on `develop`. Public contract is not `/actuator/health`.
 
 ## Why not “just expose `/v3/api-docs`”
 

--- a/70-Engineering-practices/01-Coding-standards.md
+++ b/70-Engineering-practices/01-Coding-standards.md
@@ -21,7 +21,7 @@ All Gym Buddies application repositories. This wiki uses Markdown rules in [04-D
 
 ## Java (backend)
 
-- Target **Java 26** (fallback Java 25 LTS if a dependency cannot run on 26)
+- Target **Java 25 LTS**
 - `null` avoided at boundaries: `Optional` for absence, Bean Validation on incoming payloads
 - Constructor injection only; no field `@Autowired`
 - Packages follow modules (`…auth`, `…events`, `…suggestions`)

--- a/70-Engineering-practices/06-Versioning.md
+++ b/70-Engineering-practices/06-Versioning.md
@@ -34,14 +34,14 @@ Documentation and application artifacts may sit on different `0.y.z` numbers unt
 | `0.1.0` | Docs + service | Assignment text; pipeline probe |
 | `0.1.1` | Service | GHCR + VPS probe replace |
 | `0.2.0` | Docs (2026-08-14) | Wiki process, specs, Gitflow, CI/CD contract |
-| **`0.2.0` (application, planned)** | Service + UI + OpenAPI | PostgreSQL 18, Redis, MinIO, **Java 26 / Spring Boot service layer**, basic **sign-up / sign-in / log-out** pages. Local compose already specified. |
+| **`0.2.0` (application, planned)** | Service + UI + OpenAPI | PostgreSQL 18, Redis, MinIO, **Java 25 LTS / Spring Boot service layer**, basic **sign-up / sign-in / log-out** pages. Local compose already specified. |
 | `1.0.0` | All four repos, same day | Academic ship |
 
 Application `0.2.0` is done when all of these are true on `develop` and then tagged on `main` via Release:
 
-1. `gym-buddy-service` is a Spring Boot app (Java 26) with Flyway, `GET /api/v1/healthz` and `GET /api/v1/readyz`
+1. `gym-buddy-service` is a Spring Boot app (Java 25 LTS) with Flyway, `GET /api/v1/healthz` and `GET /api/v1/readyz`
 2. Local `compose.yaml` runs PostgreSQL 18, Redis, MinIO, and that API on `127.0.0.1`
-3. OpenAPI documents register / login / logout / refresh under `/api/v1/auth` (`healthz` / `readyz` replace the stub `/health`)
+3. OpenAPI documents register / login / logout / refresh under `/api/v1/auth` (`healthz` / `readyz` already on the stub)
 4. JWT access + refresh as in [../40-Technical-specifications/02-JWT-authentication.md](../40-Technical-specifications/02-JWT-authentication.md); logout denylists refresh `jti` in Redis
 5. `gym-buddy-ui` has a basic sign-up, sign-in, and log-out page that call that API
 6. Each repo changelog records the slice under `## [0.2.0]`

--- a/70-Engineering-practices/06-Versioning.md
+++ b/70-Engineering-practices/06-Versioning.md
@@ -37,9 +37,11 @@ Documentation and application artifacts may sit on different `0.y.z` numbers unt
 | **`0.2.0` (application, planned)** | Service + UI + OpenAPI | PostgreSQL 18, Redis, MinIO, **Java 25 LTS / Spring Boot service layer**, basic **sign-up / sign-in / log-out** pages. Local compose already specified. |
 | `1.0.0` | All four repos, same day | Academic ship |
 
+On `develop` today (ticket #11, not yet a product tag): `gym-buddy-service` is already a Spring Boot app (Java 25 LTS) with Flyway **V1 baseline**, `GET /api/v1/healthz` and `GET /api/v1/readyz`. Register / login / logout are **not** shipped.
+
 Application `0.2.0` is done when all of these are true on `develop` and then tagged on `main` via Release:
 
-1. `gym-buddy-service` is a Spring Boot app (Java 25 LTS) with Flyway, `GET /api/v1/healthz` and `GET /api/v1/readyz`
+1. `gym-buddy-service` is a Spring Boot app (Java 25 LTS) with Flyway, `GET /api/v1/healthz` and `GET /api/v1/readyz` (this item is on `develop`)
 2. Local `compose.yaml` runs PostgreSQL 18, Redis, MinIO, and that API on `127.0.0.1`
 3. OpenAPI documents register / login / logout / refresh under `/api/v1/auth` (`healthz` / `readyz` already on the stub)
 4. JWT access + refresh as in [../40-Technical-specifications/02-JWT-authentication.md](../40-Technical-specifications/02-JWT-authentication.md); logout denylists refresh `jti` in Redis

--- a/70-Engineering-practices/07-CI-CD.md
+++ b/70-Engineering-practices/07-CI-CD.md
@@ -75,7 +75,7 @@ Runs on `ubuntu-latest`. It never publishes.
 | --- | --- |
 | Format | CI **applies** `.github/scripts/ci/format.sh --write` in all four repos (`gym-buddy-documentation`, `gym-buddy-openapi`, `gym-buddy-service`, `gym-buddy-ui`). If the tree is dirty, `github-actions[bot]` commits and pushes. Test and smoke stay in the **same job** after apply (`GITHUB_TOKEN` pushes do not retrigger workflows). This wiki: Prettier on YAML / JSON / HTML. Markdown is **not** auto-reflowed (`*.md` stays in `.prettierignore` — tables and Mermaid). Application repos: Spotless / Prettier through the same script. `format.sh` itself is unchanged (`--check` / `--write`). Fork PRs cannot get a bot push (`GITHUB_TOKEN` cannot write a fork). Current PRs are same-repo. |
 | Test | Repo-specific tests. In this wiki: every content folder still has a `README.md`, required pipeline files exist. Later: JUnit, Angular unit tests, OpenAPI lint. |
-| Smoke | The **built** thing is started and answers HTTP. Compiling is not enough. This wiki: Jekyll writes `_site/`, a local static server is started, `curl` must get a page that contains “Gym Buddies”. Service **today** (Python probe): container starts and `GET /` returns 2xx. Service **target** (Spring): `GET /api/v1/healthz` and `GET /api/v1/readyz` return 2xx. Do not treat `/actuator/health` as the public smoke. |
+| Smoke | The **built** thing is started and answers HTTP. Compiling is not enough. This wiki: Jekyll writes `_site/`, a local static server is started, `curl` must get a page that contains “Gym Buddies”. Service **today** (Java 25 LTS / Spring, `pom.xml` on `develop`): container starts and **`GET /api/v1/healthz`** returns 2xx. `readyz` is implemented (`200` / `503` with `postgres` / `objectStorage`) but CI smoke does **not** hit it — the image is built without Postgres/MinIO. Do not treat `/actuator/health` as the public smoke. |
 
 Required check name on `develop`: **`ci`**.
 
@@ -192,7 +192,7 @@ Each repository owns four scripts. Workflows call them; they do not inline stack
 | `.github/scripts/ci/next_version.py` | no | yes |
 | `.github/scripts/ci/prepare_changelog.py` | no | yes |
 
-When application code appears, **change the scripts**, not the workflow names or triggers. The contract on this page stays. Service smoke moves from `GET /` to `/api/v1/healthz` + `/readyz` when `pom.xml` exists.
+When application code grows, **change the scripts**, not the workflow names or triggers. The contract on this page stays. Service CI smoke is `GET /api/v1/healthz` (`pom.xml` exists). Probe `GET /` is not today’s smoke.
 
 ## What to say at the defense
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -20,13 +20,14 @@ Until the first application release, versions refer to the **documentation contr
 - Ticket form requires [`70-Engineering-practices`](../70-Engineering-practices/README.md) on every issue (code style, git, PRs, CI/CD) so every repo and every agent follows the same workflow
 - Planned **application `0.2.0`**: PostgreSQL 18, Redis, MinIO, Java 25 LTS / Spring Boot service layer, `healthz` / `readyz`, JWT register / login / logout, basic sign-up / sign-in / log-out pages. Out of scope: friends, feed, events, search, chat, admin UI, VPS data plane
 - Local data plane is now in `gym-buddy-service` (`compose.yaml`, `.env.example`); MailHog stays behind the `mail` profile
+- Application service layer on `gym-buddy-service` `develop` (ticket #11): Java 25 LTS / Spring Boot (`pom.xml`), Flyway `V1` baseline, `GET /api/v1/healthz` and `GET /api/v1/readyz`
 
 ### Changed
 
 - CI applies `format.sh --write` in all four repos; `github-actions[bot]` commits if the tree is dirty. Test and smoke stay in the same job. Docs Prettier still ignores `*.md`
 - Implementation branches are created or linked from the ticket’s Development panel so the project item shows the branch. The ticket form cannot auto-link a future branch
 - Related-repository table now uses the four real GitHub URLs
-- CI/CD: VM replace is `replace.sh` + `docker run` on `127.0.0.1`, not `docker compose up -d`; GHCR login on the VM; probe smoke is `GET /`, target is `/api/v1/healthz` and `/readyz`
+- CI/CD: VM replace is `replace.sh` + `docker run` on `127.0.0.1`, not `docker compose up -d`; GHCR login on the VM; service CI smoke is `GET /api/v1/healthz` (not probe `GET /`)
 - Hosting: backend is the OVH VPS `vps-c39cdf03.vps.ovh.net`, not a generic PaaS
 - Fixtures: Datafaker (Java), not `@faker-js/faker`
 - Technology-choices cadence row: Approved
@@ -34,9 +35,9 @@ Until the first application release, versions refer to the **documentation contr
 - Tickets: attaching to Gym Buddy Project is required at creation, not later
 - Tickets: citing `70-Engineering-practices` is required at creation
 - Versioning: application `0.2.0` is defined as the first Java + data-plane + auth slice (distinct from documentation `0.2.0`)
-- Runbook today-vs-target: local compose is in the service repo; Spring / Flyway still absent
+- Runbook today-vs-target: local compose and Java 25 LTS / Spring Boot (`pom.xml`, Flyway V1) are on `gym-buddy-service` `develop`
 - Tickets: Atlas (ops agent) owns `Not Ready` → `Todo` and `In Progress` → `Done`; Done requires Sentinel confirmation against functional requirements in this wiki. Joaquim remains product owner for consult / scope and no longer makes those two board moves by hand.
-- OpenAPI stub and wiki now agree on `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11); probe smoke is still `GET /` until Spring
+- OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11); CI smoke hits `healthz` only (smoke image has no Postgres/MinIO). Probe `GET /` is not today’s service smoke
 - Approved backend stack is **Java 25 LTS** (stack rewrite, not a pin). The ~18s `setup-java` deaths were a Maven cache permission denied under `contents:read`, not Temurin 26 failing to install (same failure on 25 and 26).
 
 ## [0.2.0] — 2026-08-14

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/).
 
 Until the first application release, versions refer to the **documentation contract**. Application repos will add their own `CHANGELOG.md` and must not contradict this one on user-visible behavior.
 
-**Documentation `0.2.0` (2026-08-14) is not the application slice.** The next **product** tag on `gym-buddy-service`, `gym-buddy-ui`, and `gym-buddy-openapi` is application `0.2.0`: PostgreSQL 18, Redis, MinIO, Java 26 / Spring Boot service layer, and basic sign-up / sign-in / log-out. See [../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md).
+**Documentation `0.2.0` (2026-08-14) is not the application slice.** The next **product** tag on `gym-buddy-service`, `gym-buddy-ui`, and `gym-buddy-openapi` is application `0.2.0`: PostgreSQL 18, Redis, MinIO, Java 25 LTS / Spring Boot service layer, and basic sign-up / sign-in / log-out. See [../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md).
 
 ## [Unreleased]
 
@@ -18,7 +18,7 @@ Until the first application release, versions refer to the **documentation contr
 - Academic report chapter map, presentation speaker notes, screenshot checklist including VPS health
 - Ticket form auto-adds every new issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1) (`projects: Projet-de-compensation-2025-2026/1`) and requires a confirmation checkbox
 - Ticket form requires [`70-Engineering-practices`](../70-Engineering-practices/README.md) on every issue (code style, git, PRs, CI/CD) so every repo and every agent follows the same workflow
-- Planned **application `0.2.0`**: PostgreSQL 18, Redis, MinIO, Java 26 / Spring Boot service layer, `healthz` / `readyz`, JWT register / login / logout, basic sign-up / sign-in / log-out pages. Out of scope: friends, feed, events, search, chat, admin UI, VPS data plane
+- Planned **application `0.2.0`**: PostgreSQL 18, Redis, MinIO, Java 25 LTS / Spring Boot service layer, `healthz` / `readyz`, JWT register / login / logout, basic sign-up / sign-in / log-out pages. Out of scope: friends, feed, events, search, chat, admin UI, VPS data plane
 - Local data plane is now in `gym-buddy-service` (`compose.yaml`, `.env.example`); MailHog stays behind the `mail` profile
 
 ### Changed
@@ -37,6 +37,7 @@ Until the first application release, versions refer to the **documentation contr
 - Runbook today-vs-target: local compose is in the service repo; Spring / Flyway still absent
 - Tickets: Atlas (ops agent) owns `Not Ready` → `Todo` and `In Progress` → `Done`; Done requires Sentinel confirmation against functional requirements in this wiki. Joaquim remains product owner for consult / scope and no longer makes those two board moves by hand.
 - OpenAPI stub and wiki now agree on `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11); probe smoke is still `GET /` until Spring
+- Approved backend stack is **Java 25 LTS** (stack rewrite, not a pin). The ~18s `setup-java` deaths were a Maven cache permission denied under `contents:read`, not Temurin 26 failing to install (same failure on 25 and 26).
 
 ## [0.2.0] — 2026-08-14
 

--- a/91-Critical-analysis/01-Current-analysis.md
+++ b/91-Critical-analysis/01-Current-analysis.md
@@ -19,7 +19,6 @@ This page is updated after implementation. It already records **design-level** s
 
 ## Weaknesses
 
-- Java 26 is the latest GA but not the LTS (that is 25). A library may force a temporary pin to 25.
 - TypeScript 7.0 is new (Go native compiler, July 2026). Angular 22 may trail it by a patch; that gap is a tooling risk, not a product one.
 - GitHub Pages cannot host the Java API or PostgreSQL. The API runs on the OVH VPS; 443 is limited to the operator network, so a stranger cannot open the demo URL without that prefix on UFW.
 - JWT HS256 + Redis denylist is not an identity platform (no step-up auth, no device list).

--- a/91-Critical-analysis/01-Current-analysis.md
+++ b/91-Critical-analysis/01-Current-analysis.md
@@ -27,7 +27,7 @@ This page is updated after implementation. It already records **design-level** s
 - Search quality on messy city strings will be poor without geocoding.
 - Instant messaging is not E2E encrypted; staff can read plaintext in the DB.
 - Large fixtures with shared image keys make the demo look repetitive.
-- The service is still a Python probe. Spring, compose, and Angular are not started.
+- Angular is not started. Register / login / logout are not shipped. The VPS still runs one API container (no data-plane compose). Flyway on `develop` is V1 baseline only.
 
 ## Risks
 
@@ -42,4 +42,4 @@ This page is updated after implementation. It already records **design-level** s
 
 ## Academic honesty
 
-Do not claim machine learning if we ship weighted sums. The justification pages exist so the defense can be precise. Do not claim Spring is in production while the probe image is what Deploy ships.
+Do not claim machine learning if we ship weighted sums. The justification pages exist so the defense can be precise. `gym-buddy-service` `develop` is Java 25 LTS / Spring Boot (`pom.xml`); do not claim the last tagged VPS image (`v0.1.1`) until a new Release. Do not claim register / login / logout or VPS compose.

--- a/99-Academic-deliverables/02-Presentation.md
+++ b/99-Academic-deliverables/02-Presentation.md
@@ -30,7 +30,7 @@ If demo environments fail, slides 4–6 become the recorded video. Keep that fil
 
 ## Q&A (30 min) — likely questions
 
-- Why Java 26 / why not the 25 LTS? Why Angular rather than React?
+- Why Java 25 LTS? Why Angular rather than React?
 - How do you stop a stranger fetching an image key?
 - Complexity of suggestions on 3k users?
 - What happens when two accepts race?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wiki-only update. Joaquim approved **Java 25 LTS** as the backend stack (not a pin, not a deferred Java 26 target). Live pages name **Java 25 LTS** only.

`gym-buddy-service` **develop** now has that stack (service #3 / ticket #11): `pom.xml`, Spring Boot, Flyway **V1 baseline**, `GET /api/v1/healthz` and `GET /api/v1/readyz`. Today-rows match that. They no longer say the service is the Python probe or that `pom.xml` is missing.

- `03-Backend.md`: today is Java 25 LTS / Spring Boot on `develop`.
- `04-Environment-and-pipeline.md`: today smoke is CI `GET /api/v1/healthz`. `readyz` is implemented (`200` / `503` with `details` for `postgres` / `objectStorage`); CI does not hit `readyz` because the smoke image is built without Postgres/MinIO. Probe `GET /` is not today’s service smoke.
- Changelog Unreleased records the service layer on `develop` (ticket #11).
- Stub **and** service implement `healthz` / `readyz`. Public contract is not `/actuator/health`.

`07-Technology-choices.md` records that Joaquim chose 25 LTS for stability. Changelog Unreleased may mention the ~18s `setup-java` deaths as a Maven cache permission denied under `contents:read`, not Temurin 26 failing to install. The dated `[0.2.0]` section still says Java 26 because that was the contract on 2026-08-14.

Does **not** claim register / login / logout (not shipped). Does **not** claim VPS compose or domain tables beyond Flyway V1. Does **not** close tickets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de8b39d2-1a15-441e-ae92-1c150f3d6d2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de8b39d2-1a15-441e-ae92-1c150f3d6d2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

