### PR TITLE
ci: apply formatter and push instead of failing --check

### DIFF
--- a/.github/scripts/ci/format.sh
+++ b/.github/scripts/ci/format.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Format the wiki. CI passes --check; Release passes --write.
+# Format the wiki. Default is --check; CI and Release pass --write.
 set -euo pipefail
 
 root="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [develop]
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -32,8 +35,20 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: false
 
-      - name: Format
-        run: bash .github/scripts/ci/format.sh --check
+      - name: Format (apply)
+        run: bash .github/scripts/ci/format.sh --write
+
+      - name: Commit formatter output
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- .github _config.yml _includes .prettierrc.json
+          if git diff --cached --quiet; then
+            echo "No formatter changes"
+          else
+            git commit -m "style: apply formatter"
+            git push
+          fi
 
       - name: Test
         run: bash .github/scripts/ci/test.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
CI now applies Prettier and pushes the result instead of failing a format check. Wiki/process markdown is unchanged (Atlas owns the contract wording).

## What changed

- `.github/workflows/ci.yml`
  - `permissions.contents: write` on this job
  - Checkout the PR/branch head (`github.head_ref || github.ref_name`) with `GITHUB_TOKEN`, not the merge ref
  - Run `bash .github/scripts/ci/format.sh --write`
  - If formatter output is dirty, commit as `github-actions[bot]` (`41898282+github-actions[bot]@users.noreply.github.com`) with `style: apply formatter` and push
  - If nothing changed, continue
  - No later `--check` that can fail the job
- `.github/scripts/ci/format.sh` comment only (behavior unchanged: Prettier 3.6.2, default `--check`, markdown ignored)

`deploy.yml` and Release are untouched. Release already uses `--write`.

## Out of scope

Atlas owns `07-CI-CD`, the runbook, and coding standards. This PR is pipeline only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea520b77-40b3-41d8-9eb4-eaf5da168f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea520b77-40b3-41d8-9eb4-eaf5da168f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

