### PR TITLE
CI applies format; link branches from the ticket

### DIFF
--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -21,6 +21,7 @@ body:
         Atlas alone sets **Not Ready** → **Todo**.
         Atlas sets **In Progress** → **Done** only after Sentinel confirms the work was implemented
         and satisfies the functional requirements. No other transitions.
+        After **Todo**, create each implementation branch from the issue’s **Development → Create a branch**, or link the PR/branch there. This form cannot auto-link a future branch.
 
         Start here: [`70-Engineering-practices`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/tree/develop/70-Engineering-practices).
   - type: dropdown

--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -112,7 +112,7 @@ Read from the live workflows on `develop` (August 2026). The public documentatio
 
 | Workflow | File | Trigger | What it does |
 | --- | --- | --- |
-| **CI** | `.github/workflows/ci.yml` | `pull_request` and `push` to `develop` only. **No** `workflow_dispatch`. | Format `--check`, tests, smoke. Never publishes. |
+| **CI** | `.github/workflows/ci.yml` | `pull_request` and `push` to `develop` only. **No** `workflow_dispatch`. | Format `--write` (apply; `github-actions[bot]` commits if dirty), then tests, then smoke in the same job. Never publishes. |
 | **Release** | `.github/workflows/release.yml` | **`workflow_dispatch` only**. Inputs: optional `version`, `bump` (`auto` / `patch` / `minor` / `major`). | Format `--write`, tests, smoke, compute SemVer, move changelog, commit prep on `develop`, **squash-merge `develop` onto `main`**, annotated tag `vX.Y.Z`, sync `main` back to `develop`, then **calls Deploy**. |
 | **Deploy** | `.github/workflows/deploy.yml` | `workflow_call` from Release, or a `v*` tag. | Build and push `ghcr.io/projet-de-compensation-2025-2026/gym-buddy-service:vX.Y.Z` (and `:latest`). SSH to the VPS and run `deploy/replace.sh`. |
 

--- a/70-Engineering-practices/01-Coding-standards.md
+++ b/70-Engineering-practices/01-Coding-standards.md
@@ -15,8 +15,8 @@ All Gym Buddies application repositories. This wiki uses Markdown rules in [04-D
 3. No secrets in git. `.env.example` / `application-example.yml` list keys only.
 4. Fail closed: missing auth → 401; missing ACL → 404.
 5. Functions that implement FS/TS IDs mention those IDs in the test name.
-6. Format on commit (Spotless / Palantir for Java, Prettier + Angular ESLint for the frontend).
-7. Lint must pass in CI.
+6. Format with the repo tools (Spotless / Palantir for Java, Prettier + Angular ESLint for the frontend). CI **applies** `format.sh --write`; `github-actions[bot]` commits if the tree is dirty. A format-on-commit hook is not required.
+7. The tree must be clean after that bot commit (and after merge). Test and smoke still run in the same CI job.
 8. HTTP shapes come from `gym-buddy-openapi`, not from ad-hoc DTOs that drift.
 
 ## Java (backend)

--- a/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
+++ b/70-Engineering-practices/05-Tickets-and-GitHub-projects.md
@@ -69,6 +69,10 @@ A ticket that exists only in the repo issues list, and not on [Gym Buddy Project
 
 A ticket may produce many commits (spec tweak, OpenAPI, backend, tests, frontend). All of them keep the same scope `(#42)` as long as they are for that ticket.
 
+## Ticket and branch
+
+GitHub does not show a branch on the project ticket until the issue and the branch are associated. Create each implementation branch from the issue’s **Development → Create a branch** action, or link the PR/branch there, so the project item exposes it. Several branches or PRs can be linked to one ticket. The ticket form cannot auto-create or auto-link a future branch. The feature sequence is in [08-Feature-implementation.md](08-Feature-implementation.md).
+
 ## Commits without a ticket
 
 If there is no ticket, **do not** put a ticket number in the commit scope. Use a topical scope (`wiki`, `ci`, `deps`). Do not create dummy issues after the fact just to decorate a typo-fix unless you want the board to show it.
@@ -78,6 +82,8 @@ If there is no ticket, **do not** put a ticket number in the commit scope. Use a
 Exactly four. These replace any older Backlog / Ready / In review layout.
 
 Atlas alone sets `Not Ready` → `Todo`. Atlas sets `In Progress` → `Done` only after Sentinel confirms the work was implemented and satisfies the functional requirements. No other transitions.
+
+Create each implementation branch from the issue’s **Development → Create a branch** action, or link the PR/branch there, so the project item exposes it.
 
 | Status | Meaning | Who sets it |
 | --- | --- | --- |

--- a/70-Engineering-practices/07-CI-CD.md
+++ b/70-Engineering-practices/07-CI-CD.md
@@ -73,7 +73,7 @@ Runs on `ubuntu-latest`. It never publishes.
 
 | Step | What “pass” means |
 | --- | --- |
-| Format | The tree matches the formatter. This wiki: Prettier on YAML / JSON / HTML (`prettier --check`). Markdown is **not** auto-reflowed (tables and Mermaid). Application repos: Spotless / Prettier. CI does **not** rewrite files. |
+| Format | CI **applies** `.github/scripts/ci/format.sh --write` in all four repos (`gym-buddy-documentation`, `gym-buddy-openapi`, `gym-buddy-service`, `gym-buddy-ui`). If the tree is dirty, `github-actions[bot]` commits and pushes. Test and smoke stay in the **same job** after apply (`GITHUB_TOKEN` pushes do not retrigger workflows). This wiki: Prettier on YAML / JSON / HTML. Markdown is **not** auto-reflowed (`*.md` stays in `.prettierignore` — tables and Mermaid). Application repos: Spotless / Prettier through the same script. `format.sh` itself is unchanged (`--check` / `--write`). Fork PRs cannot get a bot push (`GITHUB_TOKEN` cannot write a fork). Current PRs are same-repo. |
 | Test | Repo-specific tests. In this wiki: every content folder still has a `README.md`, required pipeline files exist. Later: JUnit, Angular unit tests, OpenAPI lint. |
 | Smoke | The **built** thing is started and answers HTTP. Compiling is not enough. This wiki: Jekyll writes `_site/`, a local static server is started, `curl` must get a page that contains “Gym Buddies”. Service **today** (Python probe): container starts and `GET /` returns 2xx. Service **target** (Spring): `GET /api/v1/healthz` and `GET /api/v1/readyz` return 2xx. Do not treat `/actuator/health` as the public smoke. |
 
@@ -186,7 +186,7 @@ Each repository owns four scripts. Workflows call them; they do not inline stack
 
 | Script | CI | Release |
 | --- | --- | --- |
-| `.github/scripts/ci/format.sh` | `--check` | `--write` |
+| `.github/scripts/ci/format.sh` | `--write` (apply; bot commit if dirty) | `--write` |
 | `.github/scripts/ci/test.sh` | yes | yes |
 | `.github/scripts/ci/smoke.sh` | yes (after build) | yes (after build) |
 | `.github/scripts/ci/next_version.py` | no | yes |

--- a/70-Engineering-practices/08-Feature-implementation.md
+++ b/70-Engineering-practices/08-Feature-implementation.md
@@ -119,7 +119,7 @@ A ticket becomes `Done` when **all** of these are true:
 
 1. The behaviour in the linked spec is implemented
 2. Tests required by that spec (and [80-Testing](../80-Testing/README.md)) exist and pass
-3. Format checks pass (CI `format` / [07-CI-CD.md](07-CI-CD.md))
+3. Format is applied in CI (`format.sh --write` — [07-CI-CD.md](07-CI-CD.md)); the tree must be clean after the bot commit and after the merge
 4. The PR is merged into **`develop`**
 
 Atlas sets `In Progress` → `Done` only after Sentinel (the tests/review agent) confirms the work was implemented and satisfies the functional requirements. Joaquim does not move this by hand.

--- a/70-Engineering-practices/08-Feature-implementation.md
+++ b/70-Engineering-practices/08-Feature-implementation.md
@@ -94,6 +94,8 @@ There are exactly four. They are the Status field on **Gym Buddy Project**. Do n
 
 Atlas alone sets `Not Ready` → `Todo`. Atlas sets `In Progress` → `Done` only after Sentinel confirms the work was implemented and satisfies the functional requirements. No other transitions.
 
+Create each implementation branch from the issue’s **Development → Create a branch** action, or link the PR/branch there afterwards.
+
 | Status | Meaning | Who may set it |
 | --- | --- | --- |
 | `Not Ready` | Ticket exists, every template field is filled, it is on **Gym Buddy Project**, and it points at wiki pages. It is **not** approved for implementation. | Default at creation |
@@ -110,6 +112,8 @@ Sentinel does not gate this move: nothing is implemented yet. A verbal “looks 
 ### `Todo` → `In Progress`
 
 Set `In Progress` the moment work on the ticket begins. Do not leave a live `feature/<id>-…` branch on `Todo`.
+
+Create each implementation branch from the issue’s **Development → Create a branch** action, or link the PR/branch there afterwards. That is how GitHub records the association and how the project item shows the branch. The ticket form cannot create or auto-link a future branch. Several branches or PRs can be linked to one ticket.
 
 Implementation still follows [02-Git-workflow.md](02-Git-workflow.md): branch from `develop`, PR back to `develop`, commit scope `(#<id>)`, `Refs: Projet-de-compensation-2025-2026/gym-buddy-documentation#<id>`.
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -23,6 +23,7 @@ Until the first application release, versions refer to the **documentation contr
 
 ### Changed
 
+- CI applies `format.sh --write` in all four repos; `github-actions[bot]` commits if the tree is dirty. Test and smoke stay in the same job. Docs Prettier still ignores `*.md`
 - Related-repository table now uses the four real GitHub URLs
 - CI/CD: VM replace is `replace.sh` + `docker run` on `127.0.0.1`, not `docker compose up -d`; GHCR login on the VM; probe smoke is `GET /`, target is `/api/v1/healthz` and `/readyz`
 - Hosting: backend is the OVH VPS `vps-c39cdf03.vps.ovh.net`, not a generic PaaS

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -24,6 +24,7 @@ Until the first application release, versions refer to the **documentation contr
 ### Changed
 
 - CI applies `format.sh --write` in all four repos; `github-actions[bot]` commits if the tree is dirty. Test and smoke stay in the same job. Docs Prettier still ignores `*.md`
+- Implementation branches are created or linked from the ticket’s Development panel so the project item shows the branch. The ticket form cannot auto-link a future branch
 - Related-repository table now uses the four real GitHub URLs
 - CI/CD: VM replace is `replace.sh` + `docker run` on `127.0.0.1`, not `docker compose up -d`; GHCR login on the VM; probe smoke is `GET /`, target is `/api/v1/healthz` and `/readyz`
 - Hosting: backend is the OVH VPS `vps-c39cdf03.vps.ovh.net`, not a generic PaaS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wiki-only process update. Joaquim already approved both contracts. One PR, two topical `docs(wiki)` commits. No extra process, no extra format tools or jobs, no required commit hooks.

Does **not** claim Spring, Flyway, or `pom.xml` exist on `develop`. Does **not** touch Java version lines (Java 25 LTS remains the approved stack; this PR does not revert #15).

## CI applies format

What is now true across all four repos (`gym-buddy-documentation`, `gym-buddy-openapi`, `gym-buddy-service`, `gym-buddy-ui`):

- CI runs `format.sh --write`, then `github-actions[bot]` commits and pushes if the tree is dirty.
- Test and smoke stay in the **same job** after apply (`GITHUB_TOKEN` pushes do not retrigger workflows).
- Release already called `--write`; that stays.
- `format.sh` itself is unchanged (`--check` / `--write`).
- Docs Prettier still ignores `*.md` (tables / Mermaid). Nobody should expect markdown wrap.
- Fork PRs cannot get a bot push (`GITHUB_TOKEN` cannot write a fork). Current PRs are same-repo.

Pages updated from the old “CI does not rewrite / CI=`--check`” contract:

- `70-Engineering-practices/07-CI-CD.md`
- `10-Getting-started/04-Environment-and-pipeline.md` (runbook)
- `70-Engineering-practices/01-Coding-standards.md`
- `70-Engineering-practices/08-Feature-implementation.md` (done = clean after the bot commit / merge)
- `90-Changelog/CHANGELOG.md` Unreleased Changed

`02-Git-workflow.md` only mentioned Release format-checks, not CI `--check`, so it was left alone.

## Ticket ↔ branch association

Joaquim cannot see the branch on a project ticket. The issue template cannot auto-link a future branch.

Required workflow: create each implementation branch from the issue’s **Development → Create a branch** action, or link the PR/branch there, so GitHub records the association and the project item exposes it. Several branches/PRs can be linked to one ticket.

Added in plain language on:

- `70-Engineering-practices/08-Feature-implementation.md` (feature workflow)
- `70-Engineering-practices/05-Tickets-and-GitHub-projects.md` (board)
- `.github/ISSUE_TEMPLATE/ticket.yml` (one-liner; no new required fields)
- `90-Changelog/CHANGELOG.md` Unreleased Changed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f34cc2d7-c21a-4ee7-b9af-6bf462c89caa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f34cc2d7-c21a-4ee7-b9af-6bf462c89caa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

