### PR TITLE
Define documentation 0.3.0 as the technical foundation

### DIFF
--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -9,7 +9,7 @@ How to run Gym Buddies locally, how a change is proven and released, and how the
 
 ## Today versus target
 
-Be honest at the defense. The pipeline, the VPS, the **local data plane**, and the **Java 25 LTS / Spring Boot** service exist on `develop` (`pom.xml`, ticket #11). Register / login / logout and a VPS compose do **not**.
+Be honest at the defense. The pipeline, the VPS API replace, the **local data-plane files**, and the **Java 25 LTS / Spring Boot** service exist on `develop` (`pom.xml`, ticket #11). Register / login / logout, PostgreSQL on the VPS, and a **proven** local compose boot do **not**. That remaining work is the **documentation `0.3.0` technical foundation** ([../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md)). There is no planned application `0.2.0` next slice.
 
 | Piece | Today (August 2026) | Target (locked) |
 | --- | --- | --- |
@@ -17,7 +17,7 @@ Be honest at the defense. The pipeline, the VPS, the **local data plane**, and t
 | `gym-buddy-openapi` | OpenAPI 3.1.0 stub: `GET /healthz` and `GET /readyz` under `/api/v1` | Full contract; health stays `GET /api/v1/healthz` and `GET /api/v1/readyz` |
 | `gym-buddy-ui` | Static HTML probe | Angular 22 member app + back-office |
 | Health | Service implements unauthenticated `GET /api/v1/healthz` (liveness) and `GET /api/v1/readyz` (`200` or `503` with `details` for `postgres` / `objectStorage`). CI smoke hits **`GET /api/v1/healthz` only** — the smoke image is built without Postgres/MinIO. Probe `GET /` is not today’s service smoke. | Same public paths. Do not smoke `/actuator/health`. |
-| Local data plane | `compose.yaml` in `gym-buddy-service`: Postgres 18, Redis, MinIO, Spring API, optional MailHog. All binds `127.0.0.1`. | Same file |
+| Local data plane | `compose.yaml` in `gym-buddy-service`: Postgres 18, Redis, MinIO, Spring API, optional MailHog. All binds `127.0.0.1`. Files exist (ticket #7). **Runtime boot is not claimed** (documentation `0.3.0`). | Same file |
 | VM | One API container, bound to `127.0.0.1:8080`. Caddy terminates TLS. No compose on the VM. | Same API replace, plus a **private** data-plane compose on the Docker network (5432 / 6379 / 9000 not published) |
 | Production object storage | `SPRING_PROFILES_ACTIVE=prod` **refuses to start** if S3-compatible storage is missing | Same |
 
@@ -37,7 +37,7 @@ A laptop is ready when all of these are true:
 8. The OpenAPI stub in `gym-buddy-openapi` is the HTTP source of truth. Expand it **before** implementing a new route.
 9. Point the UI at `http://localhost:8080/api/v1`.
 
-`docker compose up -d` starts the data plane plus the Spring API. The API uses Postgres, Redis, and MinIO when those containers are up (`readyz`).
+`docker compose up -d` is how a laptop starts the data plane plus the Spring API. That boot is **not** claimed today (documentation `0.3.0`). When it is proven, the API uses Postgres, Redis, and MinIO (`readyz`).
 
 ## Local Compose
 
@@ -194,7 +194,9 @@ Caddy reverse-proxies the hostname to `127.0.0.1:8080` and obtains a Let’s Enc
 
 Do not publish the operator prefix in this public wiki.
 
-### Adding data services later
+### Adding data services (documentation `0.3.0` foundation)
+
+PostgreSQL and the Java service on the VPS are part of the documentation `0.3.0` foundation. They are **not** running on the VM today.
 
 When PostgreSQL, Redis, and MinIO move onto the VM, run them on the Docker network next to the API. Do **not** publish `5432`, `6379`, or `9000` on the host. The API container reaches them by Compose/Docker DNS. The public story stays: Caddy → `127.0.0.1:8080`.
 
@@ -208,12 +210,15 @@ Let’s Encrypt **HTTP-01** needs port **80** reachable from the world for a few
 
 ## What still has to be implemented
 
+The next slice is **documentation `0.3.0`** (technical foundation). None of the foundation items below are done.
+
 | Work | Where |
 | --- | --- |
+| Prove local compose at runtime: `docker compose up -d` on a laptop; Postgres 18, Redis, MinIO, Java 25 LTS Spring service; binds `127.0.0.1`; `GET /api/v1/healthz` 200 and `GET /api/v1/readyz` 200. Files exist (tickets #7 / #11); boot is not claimed. | Laptop + `gym-buddy-service` |
+| PostgreSQL and the Java service on the OVH VPS (`vps-c39cdf03.vps.ovh.net`). Private data-plane on the Docker network; do not publish `5432` / `6379` / `9000`. Public story stays Caddy → `127.0.0.1:8080`. Today: one `docker run` API container (tag **v0.1.1**). | Operator + `gym-buddy-service` |
+| Sign-up and sign-in (log-out stays in the same ticket) | Ticket #12 — not shipped |
 | Expand the OpenAPI contract past `healthz` / `readyz` (auth and the rest of `/api/v1`) | `gym-buddy-openapi` |
 | Angular 22 apps | `gym-buddy-ui` |
-| Sign-up / sign-in / log-out | Later ticket — not shipped |
-| Private data-plane compose on the VPS | Operator work after the API needs a database |
 | Instructor cadrage minutes | [../00-Project-brief/01-Scope-and-modules.md](../00-Project-brief/01-Scope-and-modules.md) — still **Not done** |
 
 `compose.yaml` and `.env.example` landed in `gym-buddy-service` with ticket #7.

--- a/70-Engineering-practices/06-Versioning.md
+++ b/70-Engineering-practices/06-Versioning.md
@@ -27,28 +27,27 @@ Gitflow: only commits on `main` are tagged, and only by the Release workflow ([0
 
 ## Planned slices (0.y.z)
 
-Documentation and application artifacts may sit on different `0.y.z` numbers until `1.0.0`. This wiki already tagged **documentation** `0.2.0` on 2026-08-14 (process + specs). The **application** `0.2.0` is the next feature slice on `gym-buddy-service`, `gym-buddy-ui`, and `gym-buddy-openapi`.
+Documentation and application artifacts may sit on different `0.y.z` numbers until `1.0.0`. This wiki already tagged **documentation** `0.2.0` on 2026-08-14 (process + specs). That tag stays. The next slice is **documentation `0.3.0`**: the technical-foundation contract. Application repos (`gym-buddy-service`, `gym-buddy-ui`, `gym-buddy-openapi`) stay on **`0.1.x`** until that foundation is actually done on `develop` and then tagged. There is no planned application `0.2.0` next slice.
 
 | Tag | Artifact | Meaning |
 | --- | --- | --- |
 | `0.1.0` | Docs + service | Assignment text; pipeline probe |
 | `0.1.1` | Service | GHCR + VPS probe replace |
 | `0.2.0` | Docs (2026-08-14) | Wiki process, specs, Gitflow, CI/CD contract |
-| **`0.2.0` (application, planned)** | Service + UI + OpenAPI | PostgreSQL 18, Redis, MinIO, **Java 25 LTS / Spring Boot service layer**, basic **sign-up / sign-in / log-out** pages. Local compose already specified. |
+| **`0.3.0` (documentation, planned)** | Docs | Technical-foundation contract |
+| `0.1.x` | Service / UI / OpenAPI (current) | Stay here until the documentation `0.3.0` foundation is done on `develop` and then tagged |
 | `1.0.0` | All four repos, same day | Academic ship |
 
-On `develop` today (ticket #11, not yet a product tag): `gym-buddy-service` is already a Spring Boot app (Java 25 LTS) with Flyway **V1 baseline**, `GET /api/v1/healthz` and `GET /api/v1/readyz`. Register / login / logout are **not** shipped.
+On `develop` today (ticket #11, not yet a product tag): `gym-buddy-service` is already a Spring Boot app (Java 25 LTS) with Flyway **V1 baseline**, `GET /api/v1/healthz` and `GET /api/v1/readyz`. Register / login / logout are **not** shipped. Local `compose.yaml` and `.env.example` exist (ticket #7). Runtime boot of that compose is **not** claimed. The VPS is still one `docker run` API container (tag **v0.1.1**). PostgreSQL does **not** run on the VPS today.
 
-Application `0.2.0` is done when all of these are true on `develop` and then tagged on `main` via Release:
+Documentation `0.3.0` is done when all of these are true on `develop` and then tagged on `main` via Release (coding agents can then work from this point):
 
-1. `gym-buddy-service` is a Spring Boot app (Java 25 LTS) with Flyway, `GET /api/v1/healthz` and `GET /api/v1/readyz` (this item is on `develop`)
-2. Local `compose.yaml` runs PostgreSQL 18, Redis, MinIO, and that API on `127.0.0.1`
-3. OpenAPI documents register / login / logout / refresh under `/api/v1/auth` (`healthz` / `readyz` already on the stub)
-4. JWT access + refresh as in [../40-Technical-specifications/02-JWT-authentication.md](../40-Technical-specifications/02-JWT-authentication.md); logout denylists refresh `jti` in Redis
-5. `gym-buddy-ui` has a basic sign-up, sign-in, and log-out page that call that API
-6. Each repo changelog records the slice under `## [0.2.0]`
+1. **Local compose proven at runtime** — not just files in git. `docker compose up -d` on a laptop has been booted: PostgreSQL 18, Redis, MinIO, Java 25 LTS Spring service, binds `127.0.0.1`. `GET /api/v1/healthz` returns 200 and `GET /api/v1/readyz` returns 200. Today those files exist (tickets #7 / #11); **runtime boot is not yet claimed**.
+2. **PostgreSQL and the Java service run on the existing OVH VPS** (`vps-c39cdf03.vps.ovh.net`). Not laptop-only compose. Private data-plane on the Docker network; do not publish `5432` / `6379` / `9000`. Public story stays Caddy → `127.0.0.1:8080`. Today the VM is still one `docker run` API container (tag **v0.1.1** probe/replace).
+3. **Sign-up and sign-in** (existing ticket #12; log-out stays in that ticket because it is already specified). **Not shipped today**.
+4. **Developers and coding agents can work** on `gym-buddy-service`, `gym-buddy-ui`, and `gym-buddy-openapi`, push to `develop`, and when a version is stable, update the remote machines via the existing Release → Deploy path.
 
-Out of scope for application `0.2.0`: friends, feed, events, search, chat, admin lock/role UI, production data-plane on the VPS.
+Do not invent extra product features for this slice: no friends, feed, events, search, chat, or admin UI.
 
 ## Who picks the number
 
@@ -61,7 +60,7 @@ The Release workflow computes the next version unless you type one.
 | `gh workflow run Release -f version=0.4.0` | Use **exactly** `0.4.0` (must be greater than the latest tag) |
 | `gh workflow run Release -f version=1.0.0` | Academic ship. **`1.0.0` is never chosen automatically** |
 
-For the application slice, pin the number: `gh workflow run Release -f version=0.2.0` on each of service, UI, and OpenAPI when that slice is on `develop`.
+For the documentation `0.3.0` wiki tag, pin the number on this repository when that contract is on `develop`: `gh workflow run Release -f version=0.3.0`. Application repos stay on `0.1.x` until the foundation is done; pin their numbers on those repos when they are tagged. Do not assume they become `0.3.0`.
 
 The number is written as an annotated git tag `vX.Y.Z` on the squash commit on `main`.
 
@@ -82,7 +81,7 @@ Before `1.0.0`, anything may change; we still record those changes in the change
 | OpenAPI contract (`gym-buddy-openapi`) | Yes | This **is** the public API number |
 | Backend | Yes | Implements a given contract version |
 | Frontend | Yes | Consumes a given contract version |
-| This documentation wiki | Yes | Same scheme; `0.1.0` and `0.2.0` already used for the wiki contract |
+| This documentation wiki | Yes | Same scheme; `0.1.0` and `0.2.0` already used for the wiki contract; `0.3.0` is the planned foundation contract |
 
 At `1.0.0`, tag **all four** repositories `v1.0.0` on the same day so the report can cite one number.
 
@@ -94,4 +93,4 @@ Each repository keeps a `CHANGELOG.md` in [Keep a Changelog](https://keepachange
 
 Move bullets from `Unreleased` to a dated `## [0.y.z]` section when the Release workflow squash-merges to `main`. The workflow does this itself (`prepare_changelog.py`).
 
-Planned application `0.2.0` work stays under `Unreleased` in this wiki until that slice is tagged on the application repos; then add a dated note here that the product slice shipped.
+Documentation `0.3.0` foundation work stays under `Unreleased` in this wiki until that contract is tagged on `main`. Application repos stay on `0.1.x` until the foundation is done on `develop` and then tagged; then add a dated note here that the foundation shipped.

--- a/70-Engineering-practices/README.md
+++ b/70-Engineering-practices/README.md
@@ -13,7 +13,7 @@ How we write, review, and ship code and documentation across **every** Gym Buddi
 | [03-Review-process.md](03-Review-process.md) | What a review must check (including “does it match the wiki?”) |
 | [04-Documentation-conventions.md](04-Documentation-conventions.md) | Numbering, page template, linking, changelog entries |
 | [05-Tickets-and-GitHub-projects.md](05-Tickets-and-GitHub-projects.md) | Issues live here, must link a wiki page **and this directory**, commit scope = ticket id |
-| [06-Versioning.md](06-Versioning.md) | [Semantic Versioning 2.0.0](https://semver.org/) — `0.y.z` until the academic `1.0.0`; application `0.2.0` is the first Java + data-plane + auth slice |
+| [06-Versioning.md](06-Versioning.md) | [Semantic Versioning 2.0.0](https://semver.org/) — `0.y.z` until the academic `1.0.0`; documentation `0.3.0` is the technical-foundation contract; application repos stay on `0.1.x` until it is done |
 | [07-CI-CD.md](07-CI-CD.md) | GitHub Actions: CI on `develop`, Release squash+tag onto `main`, Deploy (Pages or `replace.sh`) |
 | [08-Feature-implementation.md](08-Feature-implementation.md) | Consult Joaquim → update specs → ticket on **Gym Buddy Project** → `Not Ready` / `Todo` / `In Progress` / `Done` |
 

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/).
 
 Until the first application release, versions refer to the **documentation contract**. Application repos will add their own `CHANGELOG.md` and must not contradict this one on user-visible behavior.
 
-**Documentation `0.2.0` (2026-08-14) is not the application slice.** The next **product** tag on `gym-buddy-service`, `gym-buddy-ui`, and `gym-buddy-openapi` is application `0.2.0`: PostgreSQL 18, Redis, MinIO, Java 25 LTS / Spring Boot service layer, and basic sign-up / sign-in / log-out. See [../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md).
+**Documentation `0.3.0` is the technical-foundation contract.** Application repos stay on `0.1.x` until that foundation is done on `develop` and then tagged. Documentation `0.2.0` (2026-08-14) remains the already-tagged wiki process/specs tag. There is no planned application `0.2.0` next slice. See [../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md).
 
 ## [Unreleased]
 
@@ -18,7 +18,6 @@ Until the first application release, versions refer to the **documentation contr
 - Academic report chapter map, presentation speaker notes, screenshot checklist including VPS health
 - Ticket form auto-adds every new issue to [Gym Buddy Project](https://github.com/orgs/Projet-de-compensation-2025-2026/projects/1) (`projects: Projet-de-compensation-2025-2026/1`) and requires a confirmation checkbox
 - Ticket form requires [`70-Engineering-practices`](../70-Engineering-practices/README.md) on every issue (code style, git, PRs, CI/CD) so every repo and every agent follows the same workflow
-- Planned **application `0.2.0`**: PostgreSQL 18, Redis, MinIO, Java 25 LTS / Spring Boot service layer, `healthz` / `readyz`, JWT register / login / logout, basic sign-up / sign-in / log-out pages. Out of scope: friends, feed, events, search, chat, admin UI, VPS data plane
 - Local data plane is now in `gym-buddy-service` (`compose.yaml`, `.env.example`); MailHog stays behind the `mail` profile
 - Application service layer on `gym-buddy-service` `develop` (ticket #11): Java 25 LTS / Spring Boot (`pom.xml`), Flyway `V1` baseline, `GET /api/v1/healthz` and `GET /api/v1/readyz`
 
@@ -34,7 +33,7 @@ Until the first application release, versions refer to the **documentation contr
 - Changelog compare links point at this repository
 - Tickets: attaching to Gym Buddy Project is required at creation, not later
 - Tickets: citing `70-Engineering-practices` is required at creation
-- Versioning: application `0.2.0` is defined as the first Java + data-plane + auth slice (distinct from documentation `0.2.0`)
+- Documentation `0.3.0` is the technical-foundation contract; application repos stay on `0.1.x` until it is done. This replaces planned application `0.2.0` as the next slice. Documentation `0.2.0` (2026-08-14) stays as the wiki process/specs tag.
 - Runbook today-vs-target: local compose and Java 25 LTS / Spring Boot (`pom.xml`, Flyway V1) are on `gym-buddy-service` `develop`
 - Tickets: Atlas (ops agent) owns `Not Ready` → `Todo` and `In Progress` → `Done`; Done requires Sentinel confirmation against functional requirements in this wiki. Joaquim remains product owner for consult / scope and no longer makes those two board moves by hand.
 - OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11); CI smoke hits `healthz` only (smoke image has no Postgres/MinIO). Probe `GET /` is not today’s service smoke


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wiki-only. Joaquim’s rule (via Orbit): **documentation `0.3.0`** is the technical-foundation contract. Application repos stay on **`0.1.x`** until that foundation is done on `develop` and then tagged. Do not tag them `0.3.0` in this PR.

This **replaces** planned application `0.2.0` as the next slice. Documentation `0.2.0` (2026-08-14) stays as the already-tagged wiki process/specs tag. There are not two next-slice definitions.

Foundation **done** means:

1. Local compose proven at runtime (`docker compose up -d`; Postgres 18, Redis, MinIO, Java 25 LTS Spring; `127.0.0.1`; `healthz` / `readyz` 200). Files exist (tickets #7 / #11); **runtime boot is not claimed**.
2. PostgreSQL and the Java service on the existing OVH VPS. Private data-plane; do not publish 5432 / 6379 / 9000. Public story stays Caddy → `127.0.0.1:8080`. Today the VM is still one `docker run` API container (tag **v0.1.1**).
3. Sign-up and sign-in (ticket #12; log-out stays in that ticket). **Not shipped**.
4. Developers and coding agents can work on the three app repos, push to `develop`, and update remotes via Release → Deploy.

Does **not** claim register / login / logout shipped. Does **not** claim local compose has been booted at runtime. Does **not** claim the VPS already runs Postgres. Does **not** invent friends, feed, events, search, chat, or admin UI. Does **not** close tickets. Does **not** edit application repos.

Pages:

- `70-Engineering-practices/06-Versioning.md` — planned slices + foundation checklist
- `90-Changelog/CHANGELOG.md` — Unreleased
- `10-Getting-started/04-Environment-and-pipeline.md` — today-vs-target and remaining work
- `70-Engineering-practices/README.md` — one-line next-slice pointer (was still application `0.2.0`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6d0cb1e-50fc-4d97-bd8b-f60a45ae6ac7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6d0cb1e-50fc-4d97-bd8b-f60a45ae6ac7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

