### PR TITLE
[#12] Wiki: OpenAPI stub and UI auth pages (service still open)

### DIFF
--- a/10-Getting-started/02-Related-repositories.md
+++ b/10-Getting-started/02-Related-repositories.md
@@ -29,7 +29,7 @@ The contract is a **git artifact**, not a runtime accident:
 
 Spring may still expose `/v3/api-docs` in development as a convenience. That endpoint is **not** the source of truth. If it disagrees with `gym-buddy-openapi`, the repository wins.
 
-Today the OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz`. Those remain the public health paths — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md). The public contract is not `/actuator/health`.
+Today the OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz`. Those remain the public health paths — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md). The public contract is not `/actuator/health`. The same stub also documents `POST /api/v1/auth/register`, `/login`, `/refresh`, and `/logout` (openapi #4 / ticket #12). The service and UI have **not** shipped those operations.
 
 ## Rules for application repos
 

--- a/10-Getting-started/02-Related-repositories.md
+++ b/10-Getting-started/02-Related-repositories.md
@@ -29,7 +29,7 @@ The contract is a **git artifact**, not a runtime accident:
 
 Spring may still expose `/v3/api-docs` in development as a convenience. That endpoint is **not** the source of truth. If it disagrees with `gym-buddy-openapi`, the repository wins.
 
-Today the OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz`. Those remain the public health paths — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md). The public contract is not `/actuator/health`. The same stub also documents `POST /api/v1/auth/register`, `/login`, `/refresh`, and `/logout` (openapi #4 / ticket #12). The service and UI have **not** shipped those operations.
+Today the OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz`. Those remain the public health paths — [../40-Technical-specifications/01-API-conventions.md](../40-Technical-specifications/01-API-conventions.md). The public contract is not `/actuator/health`. The same stub also documents `POST /api/v1/auth/register`, `/login`, `/refresh`, and `/logout` (openapi #4 / ticket #12). The UI on `develop` has a basic sign-up page, sign-in page, and log-out control that call register / login / logout (ui #3). The service has **not** implemented those operations (service #5 still open).
 
 ## Rules for application repos
 

--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -9,13 +9,13 @@ How to run Gym Buddies locally, how a change is proven and released, and how the
 
 ## Today versus target
 
-Be honest at the defense. The pipeline, the VPS API replace, the **local data-plane files**, and the **Java 25 LTS / Spring Boot** service exist on `develop` (`pom.xml`, ticket #11). Register / login / logout, PostgreSQL on the VPS, and a **proven** local compose boot do **not**. That remaining work is the **documentation `0.3.0` technical foundation** ([../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md)). There is no planned application `0.2.0` next slice.
+Be honest at the defense. The pipeline, the VPS API replace, the **local data-plane files**, and the **Java 25 LTS / Spring Boot** service exist on `develop` (`pom.xml`, ticket #11). The OpenAPI stub documents auth, and the UI has sign-up / sign-in / log-out pages. End-to-end register / login / logout is **not** done (service #5 still open). PostgreSQL on the VPS and a **proven** local compose boot also do **not**. That remaining work is the **documentation `0.3.0` technical foundation** ([../70-Engineering-practices/06-Versioning.md](../70-Engineering-practices/06-Versioning.md)). There is no planned application `0.2.0` next slice.
 
 | Piece | Today (August 2026) | Target (locked) |
 | --- | --- | --- |
 | `gym-buddy-service` | Java 25 LTS / Spring Boot (`pom.xml` on `develop`). Flyway `V1__baseline.sql`. `compose.yaml` and `.env.example` are in the repo. Latest released tag **v0.1.1**. | Java 25 LTS / Spring Boot modular monolith |
-| `gym-buddy-openapi` | OpenAPI 3.1.0 stub (`info.version` `0.1.0`): `GET /healthz` and `GET /readyz` under `/api/v1`, plus `POST /auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). Service and UI have **not** shipped auth. | Full contract; health stays `GET /api/v1/healthz` and `GET /api/v1/readyz` |
-| `gym-buddy-ui` | Static HTML probe | Angular 22 member app + back-office |
+| `gym-buddy-openapi` | OpenAPI 3.1.0 stub (`info.version` `0.1.0`): `GET /healthz` and `GET /readyz` under `/api/v1`, plus `POST /auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). The UI calls those auth endpoints; the service has **not** implemented them. | Full contract; health stays `GET /api/v1/healthz` and `GET /api/v1/readyz` |
+| `gym-buddy-ui` | Angular 22 (app version `0.1.0`): `/register`, `/login`, and a log-out control that call `POST /api/v1/auth/register`, `/login`, `/logout` (ui #3). Access JWT in memory. Refresh cookie credentials sent (`path /api/v1/auth`). No friends / feed / events. End-to-end auth waits on the service. | Angular 22 member app + back-office |
 | Health | Service implements unauthenticated `GET /api/v1/healthz` (liveness) and `GET /api/v1/readyz` (`200` or `503` with `details` for `postgres` / `objectStorage`). CI smoke hits **`GET /api/v1/healthz` only** — the smoke image is built without Postgres/MinIO. Probe `GET /` is not today’s service smoke. | Same public paths. Do not smoke `/actuator/health`. |
 | Local data plane | `compose.yaml` in `gym-buddy-service`: Postgres 18, Redis, MinIO, Spring API, optional MailHog. All binds `127.0.0.1`. Files exist (ticket #7). **Runtime boot is not claimed** (documentation `0.3.0`). | Same file |
 | VM | One API container, bound to `127.0.0.1:8080`. Caddy terminates TLS. No compose on the VM. | Same API replace, plus a **private** data-plane compose on the Docker network (5432 / 6379 / 9000 not published) |
@@ -216,9 +216,9 @@ The next slice is **documentation `0.3.0`** (technical foundation). None of the 
 | --- | --- |
 | Prove local compose at runtime: `docker compose up -d` on a laptop; Postgres 18, Redis, MinIO, Java 25 LTS Spring service; binds `127.0.0.1`; `GET /api/v1/healthz` 200 and `GET /api/v1/readyz` 200. Files exist (tickets #7 / #11); boot is not claimed. | Laptop + `gym-buddy-service` |
 | PostgreSQL and the Java service on the OVH VPS (`vps-c39cdf03.vps.ovh.net`). Private data-plane on the Docker network; do not publish `5432` / `6379` / `9000`. Public story stays Caddy → `127.0.0.1:8080`. Today: one `docker run` API container (tag **v0.1.1**). | Operator + `gym-buddy-service` |
-| Sign-up and sign-in (log-out stays in the same ticket) | Ticket #12 — OpenAPI paths exist on the stub; service and UI have **not** shipped auth |
+| Sign-up and sign-in (log-out stays in the same ticket) | Ticket #12 — OpenAPI stub and UI pages are on `develop`; service #5 is still open. Product slice is **not** done |
 | Expand the OpenAPI contract past health + the four auth operations (rest of `/api/v1`) | `gym-buddy-openapi` |
-| Angular 22 apps | `gym-buddy-ui` |
+| Remaining Angular surfaces (friends / feed / events / back-office) | `gym-buddy-ui` |
 | Instructor cadrage minutes | [../00-Project-brief/01-Scope-and-modules.md](../00-Project-brief/01-Scope-and-modules.md) — still **Not done** |
 
 `compose.yaml` and `.env.example` landed in `gym-buddy-service` with ticket #7.

--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -14,7 +14,7 @@ Be honest at the defense. The pipeline, the VPS API replace, the **local data-pl
 | Piece | Today (August 2026) | Target (locked) |
 | --- | --- | --- |
 | `gym-buddy-service` | Java 25 LTS / Spring Boot (`pom.xml` on `develop`). Flyway `V1__baseline.sql`. `compose.yaml` and `.env.example` are in the repo. Latest released tag **v0.1.1**. | Java 25 LTS / Spring Boot modular monolith |
-| `gym-buddy-openapi` | OpenAPI 3.1.0 stub: `GET /healthz` and `GET /readyz` under `/api/v1` | Full contract; health stays `GET /api/v1/healthz` and `GET /api/v1/readyz` |
+| `gym-buddy-openapi` | OpenAPI 3.1.0 stub (`info.version` `0.1.0`): `GET /healthz` and `GET /readyz` under `/api/v1`, plus `POST /auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). Service and UI have **not** shipped auth. | Full contract; health stays `GET /api/v1/healthz` and `GET /api/v1/readyz` |
 | `gym-buddy-ui` | Static HTML probe | Angular 22 member app + back-office |
 | Health | Service implements unauthenticated `GET /api/v1/healthz` (liveness) and `GET /api/v1/readyz` (`200` or `503` with `details` for `postgres` / `objectStorage`). CI smoke hits **`GET /api/v1/healthz` only** — the smoke image is built without Postgres/MinIO. Probe `GET /` is not today’s service smoke. | Same public paths. Do not smoke `/actuator/health`. |
 | Local data plane | `compose.yaml` in `gym-buddy-service`: Postgres 18, Redis, MinIO, Spring API, optional MailHog. All binds `127.0.0.1`. Files exist (ticket #7). **Runtime boot is not claimed** (documentation `0.3.0`). | Same file |
@@ -168,7 +168,7 @@ If the three SSH secrets are missing, Deploy still pushes the image and **skips*
 | Today (implemented) | `GET /api/v1/readyz`: `200` when PostgreSQL and object storage are reachable, else `503` with `details` naming `postgres` and/or `objectStorage` (Testcontainers / local compose). |
 | Not today | Probe `GET /`. `/actuator/health` is not the public contract. |
 
-The OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11 / [gym-buddy-openapi#2](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi/pull/2)).
+The OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11 / [gym-buddy-openapi#2](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi/pull/2)). The stub also documents the four auth operations (openapi #4 / ticket #12); the service has **not** implemented them.
 
 ## VPS
 
@@ -216,8 +216,8 @@ The next slice is **documentation `0.3.0`** (technical foundation). None of the 
 | --- | --- |
 | Prove local compose at runtime: `docker compose up -d` on a laptop; Postgres 18, Redis, MinIO, Java 25 LTS Spring service; binds `127.0.0.1`; `GET /api/v1/healthz` 200 and `GET /api/v1/readyz` 200. Files exist (tickets #7 / #11); boot is not claimed. | Laptop + `gym-buddy-service` |
 | PostgreSQL and the Java service on the OVH VPS (`vps-c39cdf03.vps.ovh.net`). Private data-plane on the Docker network; do not publish `5432` / `6379` / `9000`. Public story stays Caddy → `127.0.0.1:8080`. Today: one `docker run` API container (tag **v0.1.1**). | Operator + `gym-buddy-service` |
-| Sign-up and sign-in (log-out stays in the same ticket) | Ticket #12 — not shipped |
-| Expand the OpenAPI contract past `healthz` / `readyz` (auth and the rest of `/api/v1`) | `gym-buddy-openapi` |
+| Sign-up and sign-in (log-out stays in the same ticket) | Ticket #12 — OpenAPI paths exist on the stub; service and UI have **not** shipped auth |
+| Expand the OpenAPI contract past health + the four auth operations (rest of `/api/v1`) | `gym-buddy-openapi` |
 | Angular 22 apps | `gym-buddy-ui` |
 | Instructor cadrage minutes | [../00-Project-brief/01-Scope-and-modules.md](../00-Project-brief/01-Scope-and-modules.md) — still **Not done** |
 

--- a/20-Architecture/03-Backend.md
+++ b/20-Architecture/03-Backend.md
@@ -7,17 +7,17 @@
 
 The approved / target backend is a single **Java 25 LTS** service (Spring Boot — see [07-Technology-choices.md](07-Technology-choices.md)) exposing HTTP and a WebSocket gateway. It **implements** the contract published in [`gym-buddy-openapi`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi); it does not own that contract.
 
-Today [`gym-buddy-service`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service) `develop` **is** that stack: `pom.xml` exists (ticket #11). Register / login / logout are not shipped.
+Today [`gym-buddy-service`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service) `develop` **is** that stack: `pom.xml` exists (ticket #11). Register / login / logout are **not** implemented on the service (service #5 still open). The UI has the matching pages (ui #3).
 
 ## Today versus target
 
 | | Today | Target |
 | --- | --- | --- |
 | Runtime | Java 25 LTS / Spring Boot (`pom.xml` on `develop`) | Java 25 LTS / Spring Boot modular monolith |
-| Contract | Service and OpenAPI stub: `GET /api/v1/healthz` and `GET /api/v1/readyz`. Public contract is **not** `/actuator/health`. | Full `/api/v1`; health stays `healthz` / `readyz` |
+| Contract | Service implements `GET /api/v1/healthz` and `GET /api/v1/readyz`. OpenAPI stub also documents `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` (openapi #4). Service has **not** implemented auth. Public contract is **not** `/actuator/health`. | Full `/api/v1`; health stays `healthz` / `readyz` |
 | Data plane | Local compose (PostgreSQL 18, Redis, MinIO). Flyway **V1 baseline** only. None on the VPS | Same local compose; private data-plane compose on the VPS; full domain schema |
 
-Do not claim register / login / logout, VPS compose, or domain tables beyond Flyway V1.
+Do not claim the service shipped register / login / logout, VPS compose, or domain tables beyond Flyway V1.
 
 ## Modules
 

--- a/20-Architecture/04-Frontend.md
+++ b/20-Architecture/04-Frontend.md
@@ -7,14 +7,14 @@
 
 The member frontend is the athlete-facing web app: **Angular 22** + **TypeScript 7.0** ([07-Technology-choices.md](07-Technology-choices.md)). It talks to the backend through a client **generated from** [`gym-buddy-openapi`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi). The static build is eligible for GitHub Pages ([08-Hosting-and-GitHub-Pages.md](08-Hosting-and-GitHub-Pages.md)).
 
-Today `gym-buddy-ui` is a static HTML probe. Angular work has not started.
+Today `gym-buddy-ui` on `develop` is Angular 22 (app version `0.1.0`, ui #3 / ticket #12): `/register`, `/login`, and a log-out control that call `POST /api/v1/auth/register`, `/login`, `/logout`. Access JWT stays in memory. Refresh cookie credentials are sent (`path /api/v1/auth`). No friends / feed / events. The service has **not** implemented those endpoints, so end-to-end sign-up / sign-in is not done.
 
 ## API base URL
 
 | Environment | `apiBaseUrl` |
 | --- | --- |
-| Local | `http://localhost:8080/api/v1` |
-| Live (operator network) | `https://vps-c39cdf03.vps.ovh.net/api/v1` once Spring exists |
+| Local | `http://127.0.0.1:8080/api/v1` (`environment.ts`; `ng serve` proxies `/api`) |
+| Live (operator network) | `https://vps-c39cdf03.vps.ovh.net/api/v1` — today’s VPS container is still the health-only replace (tag **v0.1.1**), not auth |
 
 ## Surfaces
 

--- a/40-Technical-specifications/01-API-conventions.md
+++ b/40-Technical-specifications/01-API-conventions.md
@@ -65,7 +65,7 @@ Do not publish `/actuator/health` as the contract. Actuator may exist internally
 
 | Surface | Path today | Notes |
 | --- | --- | --- |
-| `gym-buddy-service` on `develop` | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Implemented (ticket #11). `readyz` is `200` or `503` with `details` for `postgres` / `objectStorage`. |
+| `gym-buddy-service` on `develop` | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Implemented (ticket #11). `readyz` is `200` or `503` with `details` for `postgres` / `objectStorage`. Auth is **not** implemented. |
 | CI smoke | `GET /api/v1/healthz` only | The smoke image is built without Postgres/MinIO. Probe `GET /` is not today’s smoke. |
-| `gym-buddy-openapi` stub | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Stub and service agree (openapi #2 / ticket #11). |
-| This page | `healthz` / `readyz` | Source of truth for the public health contract. Not `/actuator/health`. |
+| `gym-buddy-openapi` stub | `GET /api/v1/healthz` and `GET /api/v1/readyz`, plus `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` | Health agrees with the service (openapi #2 / ticket #11). Auth is documented only (openapi #4 / ticket #12). |
+| This page | `healthz` / `readyz` | Source of truth for the public health contract. Not `/actuator/health`. Auth flows: [02-JWT-authentication.md](02-JWT-authentication.md). |

--- a/40-Technical-specifications/01-API-conventions.md
+++ b/40-Technical-specifications/01-API-conventions.md
@@ -65,7 +65,8 @@ Do not publish `/actuator/health` as the contract. Actuator may exist internally
 
 | Surface | Path today | Notes |
 | --- | --- | --- |
-| `gym-buddy-service` on `develop` | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Implemented (ticket #11). `readyz` is `200` or `503` with `details` for `postgres` / `objectStorage`. Auth is **not** implemented. |
+| `gym-buddy-service` on `develop` | `GET /api/v1/healthz` and `GET /api/v1/readyz` | Implemented (ticket #11). `readyz` is `200` or `503` with `details` for `postgres` / `objectStorage`. Auth is **not** implemented (service #5 still open). |
 | CI smoke | `GET /api/v1/healthz` only | The smoke image is built without Postgres/MinIO. Probe `GET /` is not today’s smoke. |
 | `gym-buddy-openapi` stub | `GET /api/v1/healthz` and `GET /api/v1/readyz`, plus `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` | Health agrees with the service (openapi #2 / ticket #11). Auth is documented only (openapi #4 / ticket #12). |
+| `gym-buddy-ui` on `develop` | `/register`, `/login`, log-out control | Calls `POST /api/v1/auth/register`, `/login`, `/logout` (ui #3). Access JWT in memory. Refresh cookie credentials (`path /api/v1/auth`). Locked user and invalid credentials are `403` `FORBIDDEN`. End-to-end auth is **not** done. |
 | This page | `healthz` / `readyz` | Source of truth for the public health contract. Not `/actuator/health`. Auth flows: [02-JWT-authentication.md](02-JWT-authentication.md). |

--- a/40-Technical-specifications/08-OpenAPI-contract.md
+++ b/40-Technical-specifications/08-OpenAPI-contract.md
@@ -25,7 +25,7 @@ The HTTP API is specified in a **dedicated repository**, not discovered from a r
 | --- | --- | --- |
 | Document | OpenAPI 3.1.0 stub (`info.version` `0.1.0`) | Full `/api/v1` |
 | Health | `GET /api/v1/healthz` and `GET /api/v1/readyz` (stub **and** service) | `GET /api/v1/healthz` and `GET /api/v1/readyz` |
-| Auth | Stub documents `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). Service and UI have **not** shipped them. | Same four operations, implemented |
+| Auth | Stub documents `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). UI on `develop` has `/register`, `/login`, and a log-out control that call register / login / logout (ui #3). Service has **not** implemented them (service #5 still open). | Same four operations, implemented |
 
 Locked health paths: [01-API-conventions.md](01-API-conventions.md). The service implements `healthz` / `readyz` on `develop`. Public contract is not `/actuator/health`.
 
@@ -38,7 +38,7 @@ Auth paths on the stub (server prefix `/api/v1`; [gym-buddy-openapi#4](https://g
 | `POST` | `/api/v1/auth/refresh` | Cookie only → new access, rotated refresh `jti`. |
 | `POST` | `/api/v1/auth/logout` | Revokes refresh `jti` in Redis denylist; clears cookie. |
 
-This is a contract document, not an implementation. Ticket #12 stays open until the service and UI ship register / login / logout.
+This is a contract document, not an implementation. The UI pages exist; the service has **not** landed. Ticket #12 stays open until register / login / logout works end-to-end.
 
 ## Why not “just expose `/v3/api-docs`”
 

--- a/40-Technical-specifications/08-OpenAPI-contract.md
+++ b/40-Technical-specifications/08-OpenAPI-contract.md
@@ -23,10 +23,22 @@ The HTTP API is specified in a **dedicated repository**, not discovered from a r
 
 | | Today | Target |
 | --- | --- | --- |
-| Document | OpenAPI 3.1.0 stub | Full `/api/v1` |
+| Document | OpenAPI 3.1.0 stub (`info.version` `0.1.0`) | Full `/api/v1` |
 | Health | `GET /api/v1/healthz` and `GET /api/v1/readyz` (stub **and** service) | `GET /api/v1/healthz` and `GET /api/v1/readyz` |
+| Auth | Stub documents `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). Service and UI have **not** shipped them. | Same four operations, implemented |
 
-Locked paths: [01-API-conventions.md](01-API-conventions.md). The service implements them on `develop`. Public contract is not `/actuator/health`.
+Locked health paths: [01-API-conventions.md](01-API-conventions.md). The service implements `healthz` / `readyz` on `develop`. Public contract is not `/actuator/health`.
+
+Auth paths on the stub (server prefix `/api/v1`; [gym-buddy-openapi#4](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi/pull/4)):
+
+| Method | Path | Notes (from the stub, not from a running service) |
+| --- | --- | --- |
+| `POST` | `/api/v1/auth/register` | Body: `email`, `handle`, `password`, `displayName`. Creates the user. No tokens. |
+| `POST` | `/api/v1/auth/login` | Body: `{ email, password }` → access JWT in JSON + `Set-Cookie` refresh. Access is not a cookie. |
+| `POST` | `/api/v1/auth/refresh` | Cookie only → new access, rotated refresh `jti`. |
+| `POST` | `/api/v1/auth/logout` | Revokes refresh `jti` in Redis denylist; clears cookie. |
+
+This is a contract document, not an implementation. Ticket #12 stays open until the service and UI ship register / login / logout.
 
 ## Why not “just expose `/v3/api-docs`”
 

--- a/70-Engineering-practices/06-Versioning.md
+++ b/70-Engineering-practices/06-Versioning.md
@@ -38,13 +38,13 @@ Documentation and application artifacts may sit on different `0.y.z` numbers unt
 | `0.1.x` | Service / UI / OpenAPI (current) | Stay here until the documentation `0.3.0` foundation is done on `develop` and then tagged |
 | `1.0.0` | All four repos, same day | Academic ship |
 
-On `develop` today (ticket #11, not yet a product tag): `gym-buddy-service` is already a Spring Boot app (Java 25 LTS) with Flyway **V1 baseline**, `GET /api/v1/healthz` and `GET /api/v1/readyz`. Register / login / logout are **not** shipped. Local `compose.yaml` and `.env.example` exist (ticket #7). Runtime boot of that compose is **not** claimed. The VPS is still one `docker run` API container (tag **v0.1.1**). PostgreSQL does **not** run on the VPS today.
+On `develop` today (ticket #11, not yet a product tag): `gym-buddy-service` is already a Spring Boot app (Java 25 LTS) with Flyway **V1 baseline**, `GET /api/v1/healthz` and `GET /api/v1/readyz`. The OpenAPI stub documents auth and the UI has sign-up / sign-in / log-out pages (ui #3). Register / login / logout is **not** a done product slice: the service has not implemented those operations (service #5 still open). Local `compose.yaml` and `.env.example` exist (ticket #7). Runtime boot of that compose is **not** claimed. The VPS is still one `docker run` API container (tag **v0.1.1**). PostgreSQL does **not** run on the VPS today.
 
 Documentation `0.3.0` is done when all of these are true on `develop` and then tagged on `main` via Release (coding agents can then work from this point):
 
 1. **Local compose proven at runtime** — not just files in git. `docker compose up -d` on a laptop has been booted: PostgreSQL 18, Redis, MinIO, Java 25 LTS Spring service, binds `127.0.0.1`. `GET /api/v1/healthz` returns 200 and `GET /api/v1/readyz` returns 200. Today those files exist (tickets #7 / #11); **runtime boot is not yet claimed**.
 2. **PostgreSQL and the Java service run on the existing OVH VPS** (`vps-c39cdf03.vps.ovh.net`). Not laptop-only compose. Private data-plane on the Docker network; do not publish `5432` / `6379` / `9000`. Public story stays Caddy → `127.0.0.1:8080`. Today the VM is still one `docker run` API container (tag **v0.1.1** probe/replace).
-3. **Sign-up and sign-in** (existing ticket #12; log-out stays in that ticket because it is already specified). **Not shipped today**.
+3. **Sign-up and sign-in** (existing ticket #12; log-out stays in that ticket because it is already specified). OpenAPI stub and UI pages exist on `develop`. The service has **not** landed. **Not done today**.
 4. **Developers and coding agents can work** on `gym-buddy-service`, `gym-buddy-ui`, and `gym-buddy-openapi`, push to `develop`, and when a version is stable, update the remote machines via the existing Release → Deploy path.
 
 Do not invent extra product features for this slice: no friends, feed, events, search, chat, or admin UI.

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -37,7 +37,7 @@ Until the first application release, versions refer to the **documentation contr
 - Runbook today-vs-target: local compose and Java 25 LTS / Spring Boot (`pom.xml`, Flyway V1) are on `gym-buddy-service` `develop`
 - Tickets: Atlas (ops agent) owns `Not Ready` → `Todo` and `In Progress` → `Done`; Done requires Sentinel confirmation against functional requirements in this wiki. Joaquim remains product owner for consult / scope and no longer makes those two board moves by hand.
 - OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11); CI smoke hits `healthz` only (smoke image has no Postgres/MinIO). Probe `GET /` is not today’s service smoke
-- OpenAPI stub on `develop` now also documents `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). Service and UI have not shipped auth. Ticket #12 stays open.
+- OpenAPI stub on `develop` documents `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). `gym-buddy-ui` `develop` (app version `0.1.0`, ui #3) has `/register`, `/login`, and a log-out control that call register / login / logout; access JWT stays in memory; refresh cookie credentials are sent. The service has not implemented auth (service #5 still open). Ticket #12 stays open.
 - Approved backend stack is **Java 25 LTS** (stack rewrite, not a pin). The ~18s `setup-java` deaths were a Maven cache permission denied under `contents:read`, not Temurin 26 failing to install (same failure on 25 and 26).
 
 ## [0.2.0] — 2026-08-14

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -37,6 +37,7 @@ Until the first application release, versions refer to the **documentation contr
 - Runbook today-vs-target: local compose and Java 25 LTS / Spring Boot (`pom.xml`, Flyway V1) are on `gym-buddy-service` `develop`
 - Tickets: Atlas (ops agent) owns `Not Ready` → `Todo` and `In Progress` → `Done`; Done requires Sentinel confirmation against functional requirements in this wiki. Joaquim remains product owner for consult / scope and no longer makes those two board moves by hand.
 - OpenAPI stub **and** the service implement `GET /api/v1/healthz` and `GET /api/v1/readyz` (ticket #11); CI smoke hits `healthz` only (smoke image has no Postgres/MinIO). Probe `GET /` is not today’s service smoke
+- OpenAPI stub on `develop` now also documents `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` (openapi #4 / ticket #12). Service and UI have not shipped auth. Ticket #12 stays open.
 - Approved backend stack is **Java 25 LTS** (stack rewrite, not a pin). The ~18s `setup-java` deaths were a Maven cache permission denied under `contents:read`, not Temurin 26 failing to install (same failure on 25 and 26).
 
 ## [0.2.0] — 2026-08-14

--- a/91-Critical-analysis/01-Current-analysis.md
+++ b/91-Critical-analysis/01-Current-analysis.md
@@ -27,7 +27,7 @@ This page is updated after implementation. It already records **design-level** s
 - Search quality on messy city strings will be poor without geocoding.
 - Instant messaging is not E2E encrypted; staff can read plaintext in the DB.
 - Large fixtures with shared image keys make the demo look repetitive.
-- Angular is not started. Register / login / logout are not shipped. The VPS still runs one API container (no data-plane compose). Flyway on `develop` is V1 baseline only.
+- Angular 22 auth pages exist on `develop` (ui #3). Register / login / logout is not a done product slice: the service has not implemented those operations (service #5 still open). The VPS still runs one API container (no data-plane compose). Flyway on `develop` is V1 baseline only.
 
 ## Risks
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wiki-only follow-up for ticket [#12](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-documentation/issues/12). Records two already-merged application PRs. Does **not** close the ticket.

## What is on `develop`

- [gym-buddy-openapi#4](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-openapi/pull/4) — stub documents `POST /api/v1/auth/register`, `/login`, `/refresh`, `/logout` (`info.version` stays `0.1.0`).
- [gym-buddy-ui#3](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-ui/pull/3) — Angular 22 (app version `0.1.0`) has `/register`, `/login`, and a log-out control that call register / login / logout. Access JWT stays in memory. Refresh cookie credentials are sent (`path /api/v1/auth`). No friends / feed / events. Locked user and invalid credentials are `403` `FORBIDDEN`.

## What is not done

- [gym-buddy-service#5](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service/pull/5) is still **open**. The service on `develop` has **not** implemented register / login / refresh / logout. End-to-end sign-up / sign-in is not done.
- Ticket #12 stays open / not Done. No VPS compose claim. Java 25 LTS / Spring / `pom.xml` remain today’s service.

Verified against `gym-buddy-openapi` `develop` and `gym-buddy-ui` `develop`. Paths and field names come from those trees. Nothing else was invented.

Does **not** claim the service shipped auth. Does **not** use Fixes/Closes. Does **not** edit application repos.

Refs: Projet-de-compensation-2025-2026/gym-buddy-documentation#12

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-326c9864-598d-439e-bfef-6beaee1dad09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-326c9864-598d-439e-bfef-6beaee1dad09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

