### PR TITLE
Wiki: SSH + docker logs runbook

### DIFF
--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -219,6 +219,40 @@ The API container reaches Postgres / Redis / MinIO by Docker DNS (`postgres`, `r
 
 Local compose (laptop `compose.yaml`) and VPS data-plane compose (`deploy/compose.yaml`) are different files. The laptop may bind those ports to `127.0.0.1` for `psql` / Redis Insight / the MinIO console. The VM must not.
 
+### Inspecting container logs
+
+There is no Grafana, Loki, OpenShift, or Argo log UI. Inspect is SSH plus Docker logs. Do not put those on the 8 GB VPS.
+
+SSH to `vps-c39cdf03.vps.ovh.net` (port 22, open worldwide). Do not publish the operator username or the operator IPv6 prefix.
+
+API container `gym-buddy-service` (`DEPLOY_CONTAINER_NAME`; `docker run`, not compose of the API; bound to `127.0.0.1:8080`; today `develop` **`e2ef2aa`**):
+
+```bash
+docker logs gym-buddy-service
+docker logs --tail 200 -f gym-buddy-service
+```
+
+Data-plane logs from a `gym-buddy-service` checkout on the VPS (`deploy/compose.yaml`, project `gym-buddy-vps`, network `gym-buddy-data`; Postgres 18.6, Redis, MinIO; no published `5432` / `6379` / `9000` / `9001`; host env `/etc/gym-buddy/vps.env`):
+
+```bash
+docker compose --env-file /etc/gym-buddy/vps.env -f deploy/compose.yaml logs postgres
+docker compose --env-file /etc/gym-buddy/vps.env -f deploy/compose.yaml logs redis
+docker compose --env-file /etc/gym-buddy/vps.env -f deploy/compose.yaml logs minio
+```
+
+`docker ps` lists running names if you prefer `docker logs <name>`. Laptop `compose.yaml` is a different file (published `127.0.0.1` ports). It is **not** the VPS.
+
+Loopback `GET /api/v1/healthz` and `GET /api/v1/readyz` are the pulse, not a substitute for logs:
+
+```bash
+curl -sS -D- http://127.0.0.1:8080/api/v1/healthz
+curl -sS -D- http://127.0.0.1:8080/api/v1/readyz
+```
+
+Apply / replace stays in the service operator runbook: [`docs/vps-data-plane.md`](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service/blob/develop/docs/vps-data-plane.md). Do not duplicate it here.
+
+A later log UI would need a wiki page first (loopback or the existing IPv6 lock, never public) and a Todo card before anyone implements. Not this page.
+
 ### Certificate renewal
 
 Let’s Encrypt **HTTP-01** needs port **80** reachable from the world for a few seconds during issuance or renewal. Do **not** leave 80 open in UFW after the challenge.

--- a/20-Architecture/08-Hosting-and-GitHub-Pages.md
+++ b/20-Architecture/08-Hosting-and-GitHub-Pages.md
@@ -85,6 +85,8 @@ Rejected for the API (fine as notes, not the plan): Render, Fly.io, Railway as t
 
 UFW: 22 open; 80 denied except during certificate HTTP-01; 443 allowed only from the operator IPv6 prefix configured on the server (the prefix is not written in this public wiki); 8080 denied.
 
+To inspect Java API / Postgres / Redis / MinIO logs: SSH, then `docker logs` — [Inspecting container logs](../10-Getting-started/04-Environment-and-pipeline.md#inspecting-container-logs).
+
 GitHub Actions is the only pipeline: CI on `develop`, a separate Release job onto `main`, then Deploy. Details: [../70-Engineering-practices/07-CI-CD.md](../70-Engineering-practices/07-CI-CD.md) and [../10-Getting-started/04-Environment-and-pipeline.md](../10-Getting-started/04-Environment-and-pipeline.md).
 
 A tagged squash commit on `main` **is** the GHCR deploy path. Static repos (this wiki, Angular, OpenAPI UI) go to GitHub Pages. Today’s VPS container is `gym-buddy-service` `develop` **`e2ef2aa`** (`docker run`, not compose of the API), Kernel rebuilt from develop **`e2ef2aa`** after apply (not still only `:local`). `replace.sh` skip-pull for local tags is on `develop` ([gym-buddy-service#8](https://github.com/Projet-de-compensation-2025-2026/gym-buddy-service/pull/8) / `fb1e618`). That is what is true about `replace.sh`. It is **not** a GHCR pull, a Release tag, or a successful replace-from-registry. Laptop compose remains the **local** story. Caddy is the intended public entry; it is **not** proven in this confirm. Do **not** write a completed register/login on the VPS.

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -20,6 +20,7 @@ Until the first application release, versions refer to the **documentation contr
 - Ticket form requires [`70-Engineering-practices`](../70-Engineering-practices/README.md) on every issue (code style, git, PRs, CI/CD) so every repo and every agent follows the same workflow
 - Local data plane is now in `gym-buddy-service` (`compose.yaml`, `.env.example`); MailHog stays behind the `mail` profile
 - Application service layer on `gym-buddy-service` `develop` (ticket #11): Java 25 LTS / Spring Boot (`pom.xml`), Flyway `V1` baseline, `GET /api/v1/healthz` and `GET /api/v1/readyz`
+- Environment page: SSH + `docker logs` inspect runbook for the VPS API (`gym-buddy-service`) and data-plane `postgres` / `redis` / `minio`. There is no Grafana / Loki / OpenShift / Argo log UI.
 
 ### Changed
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wiki-only. Documents inspect-via-SSH. Does **not** use Fixes/Closes. Does **not** merge.

Joaquim asked how to retrieve logs for the Java API, Postgres, Redis, and MinIO. That was not on the wiki. This PR adds the runbook.

## What this is

SSH to `vps-c39cdf03.vps.ovh.net` (port 22), then `docker logs` for `gym-buddy-service` and `docker compose … logs` for `postgres` / `redis` / `minio`. Pulse stays `GET /api/v1/healthz` and `GET /api/v1/readyz` — not a substitute for logs.

## What this is not

- No Grafana, Loki, OpenShift, or Argo. There is no log UI. Do not put those on the 8 GB VPS.
- No Kernel work.
- Does not invent Caddy access-log paths. Caddy is the intended public entry; it is **not** proven.
- Does not claim register/login on the VPS. Does not claim login-from-Pages.
- Does not bump documentation `0.3.0`.

Apply / replace stays in the service `docs/vps-data-plane.md`. Laptop `compose.yaml` is not the VPS.

Do not merge this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebbfa339-b83d-4055-8ff3-e4311972ca16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebbfa339-b83d-4055-8ff3-e4311972ca16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

