### PR TITLE
[#80] Document GET /admin/content on the staff HTTP surface

### DIFF
--- a/30-Functional-specifications/11-Admin-and-moderation.md
+++ b/30-Functional-specifications/11-Admin-and-moderation.md
@@ -46,6 +46,7 @@ All under `/api/v1`. Member `POST /reports`. Staff `/admin/*` — members get `N
 | `POST` | `/admin/users/{id}/lock` | FS-ACCT-08, FS-ADM-04 |
 | `POST` | `/admin/users/{id}/unlock` | FS-ACCT-08 |
 | `PATCH` | `/admin/users/{id}/role` | FS-ACCT-09, FS-ADM-02 |
+| `GET` | `/admin/content` | FS-ADM-03 |
 | `POST` | `/admin/content/{type}/{id}/hide` | FS-ADM-03 |
 | `POST` | `/admin/content/{type}/{id}/unhide` | FS-ADM-03 |
 | `GET` | `/admin/reports` | FS-ADM-07 |

--- a/40-Technical-specifications/09-Target-HTTP-surface.md
+++ b/40-Technical-specifications/09-Target-HTTP-surface.md
@@ -138,6 +138,7 @@ Prefix `/admin`. `role=moderator` or `admin`. Members calling these get `NOT_FOU
 | `POST` | `/admin/users/{id}/lock` | FS-ACCT-08, FS-ADM-04 | Staff |
 | `POST` | `/admin/users/{id}/unlock` | FS-ACCT-08 | Staff (also restores `closed`) |
 | `PATCH` | `/admin/users/{id}/role` | FS-ACCT-09, FS-ADM-02 | Admin only |
+| `GET` | `/admin/content` | FS-ADM-03 | Staff. Query `type=post\|comment\|event\|media`, optional `q` / `hidden` |
 | `POST` | `/admin/content/{type}/{id}/hide` | FS-ADM-03 | Staff. `type=post\|comment\|event\|media` |
 | `POST` | `/admin/content/{type}/{id}/unhide` | FS-ADM-03 | Staff |
 | `GET` | `/admin/reports` | FS-ADM-07 | Staff |

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -21,6 +21,7 @@ Until the first application release, versions refer to the **documentation contr
 
 - GitHub Pages known **member** client routes are real static files (HTTP 200) after the next UI Release. Site-root `404.html` remains the fallback for unknown paths and for parameterized routes Pages cannot enumerate (`/u/:handle`, `/posts/:id`, `/events/:id`, `/messages/:id`). Ticket **#99**. Hosting: [08-Hosting-and-GitHub-Pages.md](../20-Architecture/08-Hosting-and-GitHub-Pages.md).
 - Isolated **admin** client routes (`/admin/login`, `/admin/users`, `/admin/content`, `/admin/reports`, `/admin/media`, `/admin/fixtures`, `/admin/audit`) are copied from the `gym-buddy-admin` bundle inside `gym-buddy-ui` so they do not fall through the member `404.html`. GitHub Pages still has one root `404.html`; `admin/404.html` is not a working nested 404. Ticket **#75**.
+- Staff content moderation lists hideable posts, comments, events, and media via `GET /admin/content` (FS-ADM-03, ticket #80). Hide/unhide paths are unchanged. Members hitting `/admin/*` stay `NOT_FOUND`.
 
 ## [1.0.0] — 2026-08-30
 


### PR DESCRIPTION
Refs: Projet-de-compensation-2025-2026/gym-buddy-documentation#80

Implements FS-ADM-03.

Records `GET /admin/content` on the admin HTTP inventory so the OpenAPI `$ref` tree and the wiki agree. Hide/unhide paths are unchanged. Members still get `NOT_FOUND`.

Do **not** close the ticket from this PR.