### PR TITLE
docs(#125): Pages messaging is HTTP-only at MVP

### DIFF
--- a/30-Functional-specifications/10-Instant-messaging.md
+++ b/30-Functional-specifications/10-Instant-messaging.md
@@ -30,7 +30,7 @@ Two accepted friends; staff may inspect in back-office (no E2E).
 
 ## Business rules
 
-- Persistence first: HTTP write, then fan-out. A dropped socket never loses a message ([../40-Technical-specifications/05-Messaging-transport.md](../40-Technical-specifications/05-Messaging-transport.md)).
+- Persistence first: HTTP write, then fan-out. A dropped socket never loses a message ([../40-Technical-specifications/05-Messaging-transport.md](../40-Technical-specifications/05-Messaging-transport.md)). Live Pages uses that HTTP path as the MVP (ticket **#125**): the socket from github.io does not stay open.
 - One conversation per unordered friend pair.
 - Presence (“Online” on mockup 14) is optional Redis TTL; not required for acceptance.
 - Read receipts beyond unread count are out of scope. Unread increments until the viewer `GET`s the thread (or sends a `read` event).

--- a/40-Technical-specifications/05-Messaging-transport.md
+++ b/40-Technical-specifications/05-Messaging-transport.md
@@ -24,6 +24,10 @@ Canonical paths: [09-Target-HTTP-surface.md](09-Target-HTTP-surface.md) (`/conve
 
 `GET /api/v1/conversations/{id}/messages?before=` remains the source of truth. The frontend polls every 10 s if the socket is closed.
 
+## Today (v1.1.1)
+
+From GitHub Pages the WebSocket at `/api/v1/ws` does not stay up (browser close **1006**). `GET /api/v1/ws` without Upgrade is **426**. **HTTP fetch is the MVP** for the Pages origin: friends open a conversation with `POST /conversations`, then list and send messages over HTTP. Do not claim live WS from github.io. Ticket **#125**.
+
 ## Media messages
 
 The message row references `media_id`. The payload sent on the socket contains metadata + a signed URL minted **for that recipient** at fan-out time (or the client fetches `/media/:id/url` itself — simpler, preferred).

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -15,6 +15,8 @@ Until the first application release, versions refer to the **documentation contr
 
 ### Changed
 
+- Messaging from GitHub Pages is HTTP-only at MVP: `/api/v1/ws` does not stay open from github.io (ticket **#125**, FS-MSG-07). Fetch remains the source of truth.
+
 ## [1.1.1] — 2026-08-31
 
 ### Added


### PR DESCRIPTION
Refs: Projet-de-compensation-2025-2026/gym-buddy-documentation#125

FS-MSG-07: live v1.1.0/v1.1.1 WebSocket from github.io closes 1006. HTTP fetch is the MVP. Do not claim live WS from Pages.