### PR TITLE
Document VPS Postgres loopback for pgAdmin over SSH

### DIFF
--- a/10-Getting-started/04-Environment-and-pipeline.md
+++ b/10-Getting-started/04-Environment-and-pipeline.md
@@ -285,7 +285,7 @@ docker logs gym-buddy-service
 docker logs --tail 200 -f gym-buddy-service
 ```
 
-Data-plane logs from a `gym-buddy-service` checkout on the VPS (`deploy/compose.yaml`, project `gym-buddy-vps`, network `gym-buddy-data`; Postgres 18.6, Redis, MinIO; no published `5432` / `6379` / `9000` / `9001`; host env `/etc/gym-buddy/vps.env`):
+Data-plane logs from a `gym-buddy-service` checkout on the VPS (`deploy/compose.yaml`, project `gym-buddy-vps`, network `gym-buddy-data`; Postgres 18.6, Redis, MinIO; Postgres loopback `127.0.0.1:5432` only; Redis/MinIO unpublished; host env `/etc/gym-buddy/vps.env`):
 
 ```bash
 docker compose --env-file /etc/gym-buddy/vps.env -f deploy/compose.yaml logs postgres

--- a/90-Changelog/CHANGELOG.md
+++ b/90-Changelog/CHANGELOG.md
@@ -13,6 +13,9 @@ Until the first application release, versions refer to the **documentation contr
 
 ### Added
 
+- VPS operator runbook: Postgres on `127.0.0.1:5432` for pgAdmin over SSH.
+  Redis/MinIO stay unpublished. No public `5432`.
+
 ### Changed
 
 - Messaging from GitHub Pages is HTTP-only at MVP: `/api/v1/ws` does not stay open from github.io (ticket **#125**, FS-MSG-07). Fetch remains the source of truth.


### PR DESCRIPTION
Postgres on the VPS is `127.0.0.1:5432` only for an SSH tunnel. Redis/MinIO stay unpublished. No public 5432.

No ticket (operator tooling).